### PR TITLE
Fiks typo

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -33,6 +33,6 @@ jobs:
         uses: nais/deploy/actions/deploy@v2
         env:
           CLUSTER: dev
-          RESOURCE: .nais/naiserator.yaml
+          RESOURCE: .nais/naiserator.yml
           VAR: image=${{ steps.docker-build-push.outputs.image }}
           TELEMETRY: ${{ steps.docker-build-push.outputs.telemetry }}


### PR DESCRIPTION
Denne PRen fikser en typo i deploy-workflowen, der det stod .yaml og ikke .yml. 

<img src="https://media3.giphy.com/media/v1.Y2lkPWJkM2VhNTdlazQwbjRhMDJxZWNmaW94aDU0dGhreGlwZzB1eGFoZWM0eXlqOTZwbSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/1lAOemoi0KhPMzxczT/giphy.gif"/>