### PR TITLE
Fjern ingress

### DIFF
--- a/.nais/naiserator.yml
+++ b/.nais/naiserator.yml
@@ -7,8 +7,6 @@ metadata:
   labels:
       team: bidrag
 spec:
-  ingresses:
-    - https://bidragskalkulator-api.dev.nav.cloud.nais.io
   image: {{ image }}
   port: 8080
   replicas:


### PR DESCRIPTION
Siden vi kan bruke service discovery for intern kommunikasjon, kan man fjerne denne applikasjonen fra internett, og bare la den være intern.