### PR TITLE
Legg til barn ident til modellen til å beregne barnebidrag 

### DIFF
--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/consumer/BidragPersonConsumer.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/consumer/BidragPersonConsumer.kt
@@ -4,6 +4,7 @@ import no.nav.bidrag.bidragskalkulator.exception.NoContentException
 import no.nav.bidrag.commons.web.client.AbstractRestClient
 import no.nav.bidrag.domene.ident.Personident
 import no.nav.bidrag.transport.person.MotpartBarnRelasjonDto
+import no.nav.bidrag.transport.person.NavnFødselDødDto
 import no.nav.bidrag.transport.person.PersonRequest
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
@@ -19,13 +20,20 @@ class BidragPersonConsumer(
 ) : AbstractRestClient(restTemplate, "bidrag-person") {
 
     private val hentFamilierelasjonUri = URI.create("$bidragPersonUrl/motpartbarnrelasjon")
+    private val hentNavnFoedselDoedUri = URI.create("$bidragPersonUrl/navnfoedseldoed")
+
 
     fun hentFamilierelasjon(ident: String): MotpartBarnRelasjonDto {
         secureLogger.info("Henter familierelasjon for person $ident")
-        return postSafely(hentFamilierelasjonUri, PersonRequest(Personident(ident)), ident)
+        return postSafely(hentFamilierelasjonUri, PersonRequest(Personident(ident)), Personident(ident))
     }
 
-    private inline fun <reified T : Any> postSafely(uri: URI, request: Any, ident: String): T {
+    fun hentNavnFoedselDoed(ident: Personident): NavnFødselDødDto {
+        secureLogger.info("Henter navn, fødselsdata og eventuell død for person $ident")
+        return postSafely(hentNavnFoedselDoedUri, PersonRequest(ident), ident)
+    }
+
+    private inline fun <reified T : Any> postSafely(uri: URI, request: Any, ident: Personident): T {
         return try {
             postForNonNullEntity<T>(uri, request)
         } catch (e: HttpServerErrorException) {

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/consumer/BidragPersonConsumer.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/consumer/BidragPersonConsumer.kt
@@ -20,7 +20,7 @@ class BidragPersonConsumer(
 ) : AbstractRestClient(restTemplate, "bidrag-person") {
 
     private val hentFamilierelasjonUri = URI.create("$bidragPersonUrl/motpartbarnrelasjon")
-    private val hentNavnFoedselDoedUri = URI.create("$bidragPersonUrl/navnfoedseldoed")
+    private val hentNavnFødselDødUri = URI.create("$bidragPersonUrl/navnfoedseldoed")
 
 
     fun hentFamilierelasjon(ident: String): MotpartBarnRelasjonDto {
@@ -28,9 +28,9 @@ class BidragPersonConsumer(
         return postSafely(hentFamilierelasjonUri, PersonRequest(Personident(ident)), Personident(ident))
     }
 
-    fun hentNavnFoedselDoed(ident: Personident): NavnFødselDødDto {
+    fun hentNavnFødselDød(ident: Personident): NavnFødselDødDto {
         secureLogger.info("Henter navn, fødselsdata og eventuell død for person $ident")
-        return postSafely(hentNavnFoedselDoedUri, PersonRequest(ident), ident)
+        return postSafely(hentNavnFødselDødUri, PersonRequest(ident), ident)
     }
 
     private inline fun <reified T : Any> postSafely(uri: URI, request: Any, ident: Personident): T {

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/controller/BeregningController.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/controller/BeregningController.kt
@@ -10,29 +10,12 @@ import jakarta.validation.Valid
 import no.nav.bidrag.bidragskalkulator.config.SecurityConstants
 import no.nav.bidrag.bidragskalkulator.service.BeregningService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import no.nav.security.token.support.core.api.Unprotected
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/beregning")
 @ProtectedWithClaims(issuer = SecurityConstants.TOKENX)
 class BeregningController(private val beregningService: BeregningService) {
-
-    @Operation(summary = "Beregner barnebidrag",
-        description = "Beregner barnebidrag basert på inntekten til foreldre og barnets alder. Returnerer 200 ved vellykket beregning.")
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "Beregning fullført"),
-            ApiResponse(responseCode = "400", description = "Ugyldig forespørsel - mangler eller feil i inputdata"),
-            ApiResponse(responseCode = "500", description = "Intern serverfeil")
-        ]
-    )
-    @PostMapping("/barnebidrag")
-    @Unprotected
-    fun beregnBarnebidrag(@Valid @RequestBody request: BeregningRequestDto): BeregningsresultatDto {
-        return beregningService.beregnBarnebidrag(request)
-    }
-
 
     @Operation(summary = "Beregner barnebidrag",
         description = "Beregner barnebidrag basert på inntekten til foreldre og barnets alder. Returnerer 200 ved vellykket beregning.",
@@ -44,7 +27,7 @@ class BeregningController(private val beregningService: BeregningService) {
             ApiResponse(responseCode = "500", description = "Intern serverfeil")
         ]
     )
-    @PostMapping("/beskyttet/barnebidrag")
+    @PostMapping("/barnebidrag")
     fun beregnBarnebidragBeskyttet(@Valid @RequestBody request: BeregningRequestDto): BeregningsresultatDto {
         return beregningService.beregnBarnebidrag(request)
     }

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/BeregningRequestDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/BeregningRequestDto.kt
@@ -1,14 +1,12 @@
 package no.nav.bidrag.bidragskalkulator.dto
 
-import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Min
-import jakarta.validation.constraints.Max
 import no.nav.bidrag.domene.enums.beregning.Samværsklasse
-import java.time.LocalDate
+import no.nav.bidrag.domene.ident.Personident
 
 @Schema(description = "Type bidrag")
 enum class BidragsType {
@@ -18,27 +16,18 @@ enum class BidragsType {
 
 @Schema(description = "Informasjon om et barn i beregningen")
 data class BarnDto(
-    @field:NotNull(message = "Alder må være satt")
-    @field:Min(value = 0, message = "Alder kan ikke være negativ")
-    @field:Max(value = 25, message = "Alder kan ikke være høyere enn 25")
-    @Schema(description = "Alder til barnet", required = true, example = "10")
-    val alder: Int,
+    @field:NotNull(message = "Unik identifikator for barnet")
+    @Schema(description = "Unik identifikator for barnet", required = true, example = "12345678901")
+    val ident: Personident,
 
     @field:NotNull(message = "samværsklasse må være satt")
-    @Schema(ref = "#/components/schemas/Samværsklasse") // Reference dynamically registered schema. See OpenApiConfig
+    @Schema(ref = "#/components/schemas/Samværsklasse") // Reference dynamically registered schema. See BeregnBarnebidragConfig
     val samværsklasse: Samværsklasse,
 
     @field:NotNull(message = "bidragstype må være satt")
     @Schema(description = "Type bidrag", required = true)
     val bidragstype: BidragsType
-){
-    @JsonIgnore
-    @Schema(hidden = true) // Hides from Swagger
-    //Når barnet har alder = 15, blir fødselsmåneden alltid satt til juli, uavhengig av den faktiske fødselsdatoen (usikkert hvor denne regelen stammer fra).
-    // Dette betyr at barnet ikke anses som 15 år før juli.
-    // I alle beregningsperioder før juli vil barnet derfor fortsatt regnes som 14 år.
-    fun getEstimertFødselsdato(): LocalDate = LocalDate.now().minusYears(alder.toLong())
-}
+)
 
 @Schema(description = "Modellen brukes til å beregne barnebidrag")
 data class BeregningRequestDto(

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/BeregningsresultatDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/BeregningsresultatDto.kt
@@ -1,7 +1,7 @@
 package no.nav.bidrag.bidragskalkulator.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
-import no.nav.bidrag.transport.behandling.felles.grunnlag.DelberegningUnderholdskostnad
+import no.nav.bidrag.domene.ident.Personident
 import java.math.BigDecimal
 
 @Schema(description = "Inneholder beregningsresultater for hvert barn i forespørselen")
@@ -11,12 +11,18 @@ data class BeregningsresultatDto(
 
 @Schema(description = "Beregnet barnebidrag for et enkelt barn")
 data class BeregningsresultatBarnDto(
+    @Schema(description = "Unik identifikator for barnet (fødselsnummer eller D-nummer)", example = "12345678901")
+    val ident: Personident,
+
+    @Schema(description = "Fullt navn til barnet", example = "Ola Nordmann")
+    val fulltNavn: String,
+
     @Schema(description = "Beregnet barnebidrag", example = "3200")
     val sum: BigDecimal,
-    @Schema(description = "Alder på barnet som beregningen gjelder for", example = "10")
-    val barnetsAlder: Int,
+
     @Schema(description = "Underholdskostnad til barnet, gruppert etter aldersintervall (0-5, 6-10, 11-14, 15+)", example = "4738")
     val underholdskostnad: BigDecimal,
+
     @Schema(description = "Typen bidrag – man skal betale eller motta bidrag", example = "PLIKTIG")
     val bidragstype: BidragsType,
 )

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/BeregningsresultatDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/BeregningsresultatDto.kt
@@ -17,6 +17,9 @@ data class BeregningsresultatBarnDto(
     @Schema(description = "Fullt navn til barnet", example = "Ola Nordmann")
     val fulltNavn: String,
 
+    @Schema(description = "Alder til barnet", example = "5")
+    val alder: Int,
+
     @Schema(description = "Beregnet barnebidrag", example = "3200")
     val sum: BigDecimal,
 

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/BrukerInformasjonDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/BrukerInformasjonDto.kt
@@ -9,20 +9,19 @@ data class PersonInformasjonDto(
     @Schema(description = "Unik identifikator for barnet (fødselsnummer eller D-nummer)", example = "12345678901")
     val ident: Personident,
 
-    @Schema(description = "Fornavn til barnet", example = "Ola")
+    @Schema(description = "Fornavn til person", example = "Ola")
     val fornavn: String,
 
-    @Schema(description = "Fullt navn til barnet", example = "Ola Nordmann")
+    @Schema(description = "Fullt navn til person", example = "Ola Nordmann")
     val fulltNavn: String,
 
-    @Schema(description = "Alder til barnet", example = "12")
+    @Schema(description = "Alder til person", example = "12")
     val alder: Int
 )
 
 @Schema(description = "Representerer en foreldre-barn-relasjon, med felles barn og motpart")
 data class BarneRelasjonDto(
-    // I enkelte tilfeller er ikke motpart registrert, og feltet kan derfor være null.
-    @Schema(description = "Motparten i relasjonen, vanligvis den andre forelderen. I enkelte tilfeller er ikke motpart registrert, og feltet kan derfor være null.")
+    @Schema(description = "Motparten i relasjonen, vanligvis den andre forelderen.")
     val motpart: PersonInformasjonDto?,
 
     @Schema(description = "Liste over felles barn mellom pålogget person og motparten")

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapper.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapper.kt
@@ -35,7 +35,7 @@ class BeregningsgrunnlagMapper(private val personService: PersonService) {
         registerModule(JavaTimeModule())
     }
 
-    fun mapTilBeregningsgrunnlag(dto: BeregningRequestDto): List<GrunnlagOgIdent> {
+    fun mapTilBeregningsgrunnlag(dto: BeregningRequestDto): List<GrunnlagOgBarnInformasjon> {
         val beregningsperiode = ÅrMånedsperiode(YearMonth.now(), YearMonth.now().plusMonths(1))
 
         return dto.barn.mapIndexed { index, søknadsbarn ->
@@ -43,17 +43,18 @@ class BeregningsgrunnlagMapper(private val personService: PersonService) {
                 personService.hentNavnFoedselDoed(søknadsbarn.ident)
             }
             val barnetsAlder = kalkulereAlder(søknadsbarn.ident.fødselsdato())
+            val søknadsbarnReferanse = "Person_Søknadsbarn_$index"
 
-            GrunnlagOgIdent(
+            GrunnlagOgBarnInformasjon(
                 ident = søknadsbarn.ident,
                 fulltNavn = barnetsInformasjon.navn,
-                barnetsAlder = barnetsAlder,
+                alder = barnetsAlder,
                 bidragsType = søknadsbarn.bidragstype,
                 grunnlag = BeregnGrunnlag(
                     periode = beregningsperiode,
-                    søknadsbarnReferanse = "Person_Søknadsbarn_$index",
-                    stønadstype = if(barnetsAlder > 18) Stønadstype.BIDRAG18AAR else Stønadstype.BIDRAG,
-                    grunnlagListe = lagGrunnlagsliste(søknadsbarn,  dto, "Person_Søknadsbarn_$index")
+                    søknadsbarnReferanse = søknadsbarnReferanse,
+                    stønadstype = if(barnetsAlder >= 18) Stønadstype.BIDRAG18AAR else Stønadstype.BIDRAG,
+                    grunnlagListe = lagGrunnlagsliste(søknadsbarn,  dto, søknadsbarnReferanse)
                 )
             )
         }
@@ -150,10 +151,10 @@ class BeregningsgrunnlagMapper(private val personService: PersonService) {
         )
 }
 
-data class GrunnlagOgIdent(
+data class GrunnlagOgBarnInformasjon(
     val ident: Personident,
     val fulltNavn: String,
-    val barnetsAlder: Int,
+    val alder: Int,
     val bidragsType: BidragsType,
     val grunnlag: BeregnGrunnlag
 )

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapper.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapper.kt
@@ -40,7 +40,7 @@ class BeregningsgrunnlagMapper(private val personService: PersonService) {
 
         return dto.barn.mapIndexed { index, søknadsbarn ->
             val barnetsInformasjon = SikkerhetsKontekst.medApplikasjonKontekst {
-                personService.hentNavnFoedselDoed(søknadsbarn.ident)
+                personService.hentNavnFødselDød(søknadsbarn.ident)
             }
             val barnetsAlder = kalkulereAlder(søknadsbarn.ident.fødselsdato())
             val søknadsbarnReferanse = "Person_Søknadsbarn_$index"

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapper.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapper.kt
@@ -6,19 +6,24 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import no.nav.bidrag.bidragskalkulator.dto.BarnDto
 import no.nav.bidrag.bidragskalkulator.dto.BeregningRequestDto
 import no.nav.bidrag.bidragskalkulator.dto.BidragsType
+import no.nav.bidrag.bidragskalkulator.service.PersonService
+import no.nav.bidrag.bidragskalkulator.utils.kalkulereAlder
+import no.nav.bidrag.commons.security.SikkerhetsKontekst
 import no.nav.bidrag.domene.enums.grunnlag.Grunnlagstype
 import no.nav.bidrag.domene.enums.inntekt.Inntektsrapportering
 import no.nav.bidrag.domene.enums.person.Bostatuskode
 import no.nav.bidrag.domene.enums.vedtak.Stønadstype
+import no.nav.bidrag.domene.ident.Personident
 import no.nav.bidrag.domene.tid.ÅrMånedsperiode
 import no.nav.bidrag.transport.behandling.beregning.felles.BeregnGrunnlag
 import no.nav.bidrag.transport.behandling.felles.grunnlag.*
 import org.springframework.stereotype.Component
 import java.math.BigDecimal
+import java.time.LocalDate
 import java.time.YearMonth
 
 @Component
-class BeregningsgrunnlagMapper {
+class BeregningsgrunnlagMapper(private val personService: PersonService) {
 
     companion object {
         private const val BIDRAGSMOTTAKER_REFERANSE = "Person_Bidragsmottaker"
@@ -30,18 +35,25 @@ class BeregningsgrunnlagMapper {
         registerModule(JavaTimeModule())
     }
 
-    fun mapTilBeregningsgrunnlag(dto: BeregningRequestDto): List<GrunnlagOgAlder> {
+    fun mapTilBeregningsgrunnlag(dto: BeregningRequestDto): List<GrunnlagOgIdent> {
         val beregningsperiode = ÅrMånedsperiode(YearMonth.now(), YearMonth.now().plusMonths(1))
 
         return dto.barn.mapIndexed { index, søknadsbarn ->
-            GrunnlagOgAlder(
-                barnetsAlder = søknadsbarn.alder,
+            val barnetsInformasjon = SikkerhetsKontekst.medApplikasjonKontekst {
+                personService.hentNavnFoedselDoed(søknadsbarn.ident)
+            }
+            val barnetsAlder = kalkulereAlder(søknadsbarn.ident.fødselsdato())
+
+            GrunnlagOgIdent(
+                ident = søknadsbarn.ident,
+                fulltNavn = barnetsInformasjon.navn,
+                barnetsAlder = barnetsAlder,
                 bidragsType = søknadsbarn.bidragstype,
                 grunnlag = BeregnGrunnlag(
                     periode = beregningsperiode,
                     søknadsbarnReferanse = "Person_Søknadsbarn_$index",
-                    stønadstype = if(søknadsbarn.alder > 18) Stønadstype.BIDRAG18AAR else Stønadstype.BIDRAG,
-                    grunnlagListe = lagGrunnlagsliste(søknadsbarn, dto, "Person_Søknadsbarn_$index")
+                    stønadstype = if(barnetsAlder > 18) Stønadstype.BIDRAG18AAR else Stønadstype.BIDRAG,
+                    grunnlagListe = lagGrunnlagsliste(søknadsbarn,  dto, "Person_Søknadsbarn_$index")
                 )
             )
         }
@@ -56,7 +68,7 @@ class BeregningsgrunnlagMapper {
             lagTomtGrunnlag(BIDRAGSMOTTAKER_REFERANSE, Grunnlagstype.PERSON_BIDRAGSMOTTAKER),
             lagTomtGrunnlag(BIDRAGSPLIKTIG_REFERANSE, Grunnlagstype.PERSON_BIDRAGSPLIKTIG),
             lagBostatusgrunnlag("Bostatus_Bidragspliktig", Bostatuskode.BOR_IKKE_MED_ANDRE_VOKSNE, null, BIDRAGSPLIKTIG_REFERANSE),
-            lagSøknadsbarngrunnlag(søknadsbarnReferanse, søknadsbarn),
+            lagSøknadsbarngrunnlag(søknadsbarnReferanse, søknadsbarn.ident.fødselsdato()),
             lagInntektsgrunnlag(
                 "Inntekt_Bidragspliktig",
                 lønnBidragspliktig.toBigDecimal(),
@@ -81,11 +93,11 @@ class BeregningsgrunnlagMapper {
     private fun lagTomtGrunnlag(referanse: String, type: Grunnlagstype) =
         GrunnlagDto(referanse, type, objectMapper.createObjectNode())
 
-    private fun lagSøknadsbarngrunnlag(søknadsbarnReferanse: String, søknadsbarn: BarnDto) =
+    private fun lagSøknadsbarngrunnlag(søknadsbarnReferanse: String, søknadsbarnsfødselsdato: LocalDate) =
         GrunnlagDto(
             referanse = søknadsbarnReferanse,
             type = Grunnlagstype.PERSON_SØKNADSBARN,
-            innhold = objectMapper.valueToTree(Person(fødselsdato = søknadsbarn.getEstimertFødselsdato()))
+            innhold = objectMapper.valueToTree(Person(fødselsdato = søknadsbarnsfødselsdato))
         )
 
     private fun lagInntektsgrunnlag(referanse: String, beløp: BigDecimal, eierReferanse: String) =
@@ -138,7 +150,9 @@ class BeregningsgrunnlagMapper {
         )
 }
 
-data class GrunnlagOgAlder(
+data class GrunnlagOgIdent(
+    val ident: Personident,
+    val fulltNavn: String,
     val barnetsAlder: Int,
     val bidragsType: BidragsType,
     val grunnlag: BeregnGrunnlag

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BidragGrunnlagMapper.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BidragGrunnlagMapper.kt
@@ -1,6 +1,5 @@
 package no.nav.bidrag.bidragskalkulator.mapper
 
-import no.nav.bidrag.domene.enums.rolle.Rolle
 import no.nav.bidrag.transport.behandling.grunnlag.response.AinntektspostDto
 import no.nav.bidrag.transport.behandling.inntekt.request.Ainntektspost
 

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BrukerInformasjonMapper.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BrukerInformasjonMapper.kt
@@ -1,14 +1,11 @@
 package no.nav.bidrag.bidragskalkulator.mapper
 
 import no.nav.bidrag.bidragskalkulator.dto.*
-import no.nav.bidrag.commons.util.secureLogger
+import no.nav.bidrag.bidragskalkulator.utils.kalkulereAlder
 import no.nav.bidrag.transport.behandling.inntekt.response.TransformerInntekterResponse
 import no.nav.bidrag.domene.enums.person.Diskresjonskode
 import no.nav.bidrag.transport.person.MotpartBarnRelasjonDto
 import no.nav.bidrag.transport.person.PersonDto
-import java.time.LocalDate
-import java.time.Period
-import java.time.format.DateTimeParseException
 
 object BrukerInformasjonMapper {
 
@@ -60,14 +57,5 @@ object BrukerInformasjonMapper {
             fulltNavn = this.person.visningsnavn,
             alder = this.person.fødselsdato?.let { kalkulereAlder(it) } ?: 0
         )
-    }
-
-    private fun kalkulereAlder(fødselsdato: LocalDate): Int {
-        return try {
-            Period.between(fødselsdato, LocalDate.now()).years
-        } catch (e: DateTimeParseException) {
-            secureLogger.warn(e) { "Feil ved kalkulering av alder for fødselsdato $fødselsdato" }
-            0
-        }
     }
 }

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/BeregningService.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/BeregningService.kt
@@ -35,7 +35,7 @@ class BeregningService(
                 ?.innholdTilObjekt<DelberegningUnderholdskostnad>()?.underholdskostnad ?: BigDecimal.ZERO
 
             BeregningsresultatBarnDto(
-                sum = beregnetSum.avrundeTilNærsteHundre(),
+                sum = beregnetSum.avrundeTilNærmesteHundre(),
                 ident = data.ident,
                 fulltNavn = data.fulltNavn,
                 alder = data.alder,
@@ -50,7 +50,7 @@ class BeregningService(
         return BeregningsresultatDto(beregningsresultat)
     }
 
-    fun BigDecimal.avrundeTilNærsteHundre() = this.divide(BigDecimal(100))
+    fun BigDecimal.avrundeTilNærmesteHundre() = this.divide(BigDecimal(100))
         .setScale(0, RoundingMode.HALF_UP)
         .multiply(BigDecimal(100))
 }

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/BeregningService.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/BeregningService.kt
@@ -38,6 +38,7 @@ class BeregningService(
                 sum = beregnetSum.avrundeTilNærsteHundre(),
                 ident = data.ident,
                 fulltNavn = data.fulltNavn,
+                alder = data.alder,
                 underholdskostnad = underholdskostnad,
                 bidragstype = data.bidragsType,
             )

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/BeregningService.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/BeregningService.kt
@@ -6,13 +6,11 @@ import no.nav.bidrag.bidragskalkulator.dto.BeregningRequestDto
 import no.nav.bidrag.bidragskalkulator.dto.BeregningsresultatBarnDto
 import no.nav.bidrag.bidragskalkulator.mapper.BeregningsgrunnlagMapper
 import no.nav.bidrag.domene.enums.grunnlag.Grunnlagstype
-import no.nav.bidrag.transport.behandling.beregning.felles.BeregnGrunnlag
 import no.nav.bidrag.transport.behandling.felles.grunnlag.*
 import org.slf4j.LoggerFactory.getLogger
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
 import java.math.RoundingMode
-import kotlin.random.Random
 
 @Service
 class BeregningService(
@@ -27,16 +25,20 @@ class BeregningService(
 
         val start = System.currentTimeMillis()
         val beregningsresultat = beregningsgrunnlag.parallelStream().map { data ->
-            val beregnetSum = beregnBarnebidragApi.beregn(data.grunnlag)
+            val beregningsResult = beregnBarnebidragApi.beregn(data.grunnlag)
+            val beregnetSum = beregningsResult
                 .beregnetBarnebidragPeriodeListe
                 .sumOf { it.resultat.beløp ?: BigDecimal.ZERO }
 
+            val underholdskostnad = beregningsResult.grunnlagListe
+                .firstOrNull { it.type == Grunnlagstype.DELBEREGNING_UNDERHOLDSKOSTNAD }
+                ?.innholdTilObjekt<DelberegningUnderholdskostnad>()?.underholdskostnad ?: BigDecimal.ZERO
+
             BeregningsresultatBarnDto(
-                sum = beregnetSum.divide(BigDecimal(100))
-                    .setScale(0, RoundingMode.HALF_UP)
-                    .multiply(BigDecimal(100)),
-                barnetsAlder = data.barnetsAlder,
-                underholdskostnad = hentUnderholdskostnad(data.grunnlag),
+                sum = beregnetSum.avrundeTilNærsteHundre(),
+                ident = data.ident,
+                fulltNavn = data.fulltNavn,
+                underholdskostnad = underholdskostnad,
                 bidragstype = data.bidragsType,
             )
         }.toList()
@@ -47,11 +49,8 @@ class BeregningService(
         return BeregningsresultatDto(beregningsresultat)
     }
 
-    internal fun hentUnderholdskostnad(grunnlag: BeregnGrunnlag): BigDecimal =
-        beregnBarnebidragApi.beregnUnderholdskostnad(grunnlag)
-            .firstOrNull { it.type == Grunnlagstype.DELBEREGNING_UNDERHOLDSKOSTNAD }
-            ?.innholdTilObjekt<DelberegningUnderholdskostnad>()
-            ?.underholdskostnad
-            ?: BigDecimal.ZERO
+    fun BigDecimal.avrundeTilNærsteHundre() = this.divide(BigDecimal(100))
+        .setScale(0, RoundingMode.HALF_UP)
+        .multiply(BigDecimal(100))
 }
 

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/PersonService.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/PersonService.kt
@@ -19,9 +19,9 @@ class PersonService(private val personConsumer: BidragPersonConsumer, private va
         return BrukerInformasjonMapper.tilBrukerInformasjonDto(familierelasjon, inntektsGrunnlag)
     }
 
-    fun hentNavnFoedselDoed(personIdent: Personident): NavnFødselDødDto {
+    fun hentNavnFødselDød(personIdent: Personident): NavnFødselDødDto {
         return  SikkerhetsKontekst.medApplikasjonKontekst {
-            personConsumer.hentNavnFoedselDoed(personIdent)
+            personConsumer.hentNavnFødselDød(personIdent)
         }
     }
 }

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/PersonService.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/PersonService.kt
@@ -4,6 +4,8 @@ import no.nav.bidrag.bidragskalkulator.consumer.BidragPersonConsumer
 import no.nav.bidrag.bidragskalkulator.dto.BrukerInformasjonDto
 import no.nav.bidrag.bidragskalkulator.mapper.BrukerInformasjonMapper
 import no.nav.bidrag.commons.security.SikkerhetsKontekst
+import no.nav.bidrag.domene.ident.Personident
+import no.nav.bidrag.transport.person.NavnFødselDødDto
 import org.springframework.stereotype.Service
 
 @Service
@@ -15,5 +17,11 @@ class PersonService(private val personConsumer: BidragPersonConsumer, private va
             personConsumer.hentFamilierelasjon(personIdent)
         }
         return BrukerInformasjonMapper.tilBrukerInformasjonDto(familierelasjon, inntektsGrunnlag)
+    }
+
+    fun hentNavnFoedselDoed(personIdent: Personident): NavnFødselDødDto {
+        return  SikkerhetsKontekst.medApplikasjonKontekst {
+            personConsumer.hentNavnFoedselDoed(personIdent)
+        }
     }
 }

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/utils/DateUtils.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/utils/DateUtils.kt
@@ -1,0 +1,18 @@
+package no.nav.bidrag.bidragskalkulator.utils
+
+
+import java.time.LocalDate
+import java.time.Period
+import java.time.format.DateTimeParseException
+import org.slf4j.LoggerFactory
+
+private val secureLogger = LoggerFactory.getLogger("secureLogger")
+
+fun kalkulereAlder(fødselsdato: LocalDate): Int {
+    return try {
+        Period.between(fødselsdato, LocalDate.now()).years
+    } catch (e: DateTimeParseException) {
+        secureLogger.warn("Feil ved kalkulering av alder for fødselsdato $fødselsdato", e)
+        0
+    }
+}

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/BeregningControllerTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/BeregningControllerTest.kt
@@ -5,6 +5,7 @@ import io.mockk.every
 import no.nav.bidrag.bidragskalkulator.dto.*
 import no.nav.bidrag.bidragskalkulator.service.BeregningService
 import no.nav.bidrag.domene.enums.beregning.Samværsklasse
+import no.nav.bidrag.domene.ident.Personident
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
@@ -16,16 +17,10 @@ class BeregningControllerTest: AbstractControllerTest() {
     @MockkBean
     private lateinit var beregningService: BeregningService
 
+
     @BeforeEach
     fun setupMocks() {
         every { beregningService.beregnBarnebidrag(mockGyldigRequest) } returns mockRespons
-    }
-
-    @Test
-    fun `skal returnere 200 OK uten token for et åpent endepunkt`() {
-        postRequest("/api/v1/beregning/barnebidrag", mockGyldigRequest)
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.resultater").isNotEmpty())
     }
 
     @Test
@@ -37,14 +32,14 @@ class BeregningControllerTest: AbstractControllerTest() {
 
     @Test
     fun `skal returnere 200 OK med gyldig OAuth2-token`() {
-        postRequest("/api/v1/beregning/beskyttet/barnebidrag", mockGyldigRequest, gyldigOAuth2Token)
+        postRequest("/api/v1/beregning/barnebidrag", mockGyldigRequest, gyldigOAuth2Token)
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.resultater").isNotEmpty())
     }
 
     @Test
     fun `skal returnere 401 Unauthorized når ingen token er gitt`() {
-        postRequest("/api/v1/beregning/beskyttet/barnebidrag", mockGyldigRequest)
+        postRequest("/api/v1/beregning/barnebidrag", mockGyldigRequest)
             .andExpect(status().isUnauthorized)
     }
 
@@ -52,7 +47,7 @@ class BeregningControllerTest: AbstractControllerTest() {
     fun `skal returnere 400 for negativ inntekt`() {
         val request = mockGyldigRequest.copy(inntektForelder1 = -500000.0)
 
-        postRequest("/api/v1/beregning/beskyttet/barnebidrag", request, gyldigOAuth2Token)
+        postRequest("/api/v1/beregning/barnebidrag", request, gyldigOAuth2Token)
             .andExpect(status().isBadRequest)
             .andExpect(jsonPath("$.errors[0]").value("inntektForelder1: Inntekt for forelder 1 kan ikke være negativ"))
     }
@@ -61,21 +56,23 @@ class BeregningControllerTest: AbstractControllerTest() {
     fun `skal returnere 400 for et tom barn liste`() {
         val request = mockGyldigRequest.copy(barn = emptyList())
 
-        postRequest("/api/v1/beregning/beskyttet/barnebidrag", request, gyldigOAuth2Token)
+        postRequest("/api/v1/beregning/barnebidrag", request, gyldigOAuth2Token)
             .andExpect(status().isBadRequest)
             .andExpect(jsonPath("$.errors[0]").value("barn: Liste over barn kan ikke være tom"))
     }
 
     companion object TestData {
+        private val personIdent = "12345678910"
+
         val mockGyldigRequest = BeregningRequestDto(
             inntektForelder1 = 500000.0,
             inntektForelder2 = 400000.0,
-            barn = listOf(BarnDto(alder = 10, samværsklasse = Samværsklasse.SAMVÆRSKLASSE_1, bidragstype = BidragsType.PLIKTIG))
+            barn = listOf(BarnDto(ident = Personident(personIdent), samværsklasse = Samværsklasse.SAMVÆRSKLASSE_1, bidragstype = BidragsType.PLIKTIG))
         )
 
         val mockRespons = BeregningsresultatDto(
             resultater = listOf(
-                BeregningsresultatBarnDto(sum = BigDecimal(100), barnetsAlder = mockGyldigRequest.barn.first().alder, underholdskostnad = BigDecimal(8471), bidragstype = mockGyldigRequest.barn.first().bidragstype)
+                BeregningsresultatBarnDto(sum = BigDecimal(100), ident = Personident(personIdent), fulltNavn = "Navn Navnesen", alder = 5, underholdskostnad = BigDecimal(8471), bidragstype = mockGyldigRequest.barn.first().bidragstype)
             )
         )
     }

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapperTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapperTest.kt
@@ -5,7 +5,6 @@ import io.mockk.mockk
 import no.nav.bidrag.bidragskalkulator.dto.BeregningRequestDto
 import no.nav.bidrag.bidragskalkulator.service.PersonService
 import no.nav.bidrag.bidragskalkulator.utils.JsonUtils
-import no.nav.bidrag.bidragskalkulator.utils.kalkulereAlder
 import no.nav.bidrag.domene.enums.vedtak.Stønadstype
 import no.nav.bidrag.transport.person.NavnFødselDødDto
 import org.junit.jupiter.api.Assertions.*
@@ -71,11 +70,19 @@ class BeregningsgrunnlagMapperTest {
     @Test
     fun `skal sette stønadstype til BIDRAG18AAR for barn over 18`() {
         val beregningRequest: BeregningRequestDto = JsonUtils.readJsonFile("/barnebidrag/beregning_barn_over_18.json")
-        println("---test-----" + kalkulereAlder(beregningRequest.barn.first().ident.fødselsdato()))
         val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlag(beregningRequest)
 
         assertEquals(1, result.size, "Forventet én beregning")
         assertEquals(Stønadstype.BIDRAG18AAR, result.first().grunnlag.stønadstype, "Stønadstype skal være BIDRAG18AAR for barn over 18")
+    }
+
+
+    @Test
+    fun `skal sette stønadstype til BIDRAG for barn under 18`() {
+        val beregningRequest: BeregningRequestDto = JsonUtils.readJsonFile("/barnebidrag/beregning_et_barn.json")
+        val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlag(beregningRequest)
+
+        assertEquals(Stønadstype.BIDRAG, result.first().grunnlag.stønadstype)
     }
 
     private fun assertBarnetsAlderOgReferanse(

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapperTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapperTest.kt
@@ -21,7 +21,7 @@ class BeregningsgrunnlagMapperTest {
         val mockPersonService = mockk<PersonService>(relaxed = true)
         val fødselsdato = LocalDate.now().minusYears(10)
 
-        every { mockPersonService.hentNavnFoedselDoed(any()) } returns NavnFødselDødDto(
+        every { mockPersonService.hentNavnFødselDød(any()) } returns NavnFødselDødDto(
             navn = "Navn Navnesen",
             fødselsdato = fødselsdato,
             fødselsår = fødselsdato.year,

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapperTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapperTest.kt
@@ -1,11 +1,17 @@
 package no.nav.bidrag.bidragskalkulator.mapper
 
+import io.mockk.every
+import io.mockk.mockk
 import no.nav.bidrag.bidragskalkulator.dto.BeregningRequestDto
+import no.nav.bidrag.bidragskalkulator.service.PersonService
 import no.nav.bidrag.bidragskalkulator.utils.JsonUtils
+import no.nav.bidrag.bidragskalkulator.utils.kalkulereAlder
 import no.nav.bidrag.domene.enums.vedtak.Stønadstype
+import no.nav.bidrag.transport.person.NavnFødselDødDto
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 
 class BeregningsgrunnlagMapperTest {
 
@@ -13,7 +19,20 @@ class BeregningsgrunnlagMapperTest {
 
     @BeforeEach
     fun setup() {
-        beregningsgrunnlagMapper = BeregningsgrunnlagMapper()
+        val mockPersonService = mockk<PersonService>(relaxed = true)
+        val fødselsdato = LocalDate.now().minusYears(10)
+
+        every { mockPersonService.hentNavnFoedselDoed(any()) } returns NavnFødselDødDto(
+            navn = "Navn Navnesen",
+            fødselsdato = fødselsdato,
+            fødselsår = fødselsdato.year,
+            dødsdato = null,
+            foedselsdato = fødselsdato,
+            foedselsaar = fødselsdato.year,
+            doedsdato = null
+        )
+
+        beregningsgrunnlagMapper = BeregningsgrunnlagMapper(mockPersonService)
     }
 
     @Test
@@ -52,7 +71,7 @@ class BeregningsgrunnlagMapperTest {
     @Test
     fun `skal sette stønadstype til BIDRAG18AAR for barn over 18`() {
         val beregningRequest: BeregningRequestDto = JsonUtils.readJsonFile("/barnebidrag/beregning_barn_over_18.json")
-
+        println("---test-----" + kalkulereAlder(beregningRequest.barn.first().ident.fødselsdato()))
         val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlag(beregningRequest)
 
         assertEquals(1, result.size, "Forventet én beregning")
@@ -60,11 +79,11 @@ class BeregningsgrunnlagMapperTest {
     }
 
     private fun assertBarnetsAlderOgReferanse(
-        grunnlagOgAlder: GrunnlagOgAlder,
+        grunnlagOgBarnInformasjon: GrunnlagOgBarnInformasjon,
         beregningRequest: BeregningRequestDto,
         index: Int
     ) {
-        assertEquals(beregningRequest.barn[index].alder, grunnlagOgAlder.barnetsAlder)
-        assertEquals("Person_Søknadsbarn_$index", grunnlagOgAlder.grunnlag.søknadsbarnReferanse)
+        assertEquals(beregningRequest.barn[index].ident, grunnlagOgBarnInformasjon.ident)
+        assertEquals("Person_Søknadsbarn_$index", grunnlagOgBarnInformasjon.grunnlag.søknadsbarnReferanse)
     }
 }

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/service/BeregningServiceValidationTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/service/BeregningServiceValidationTest.kt
@@ -12,11 +12,13 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import com.fasterxml.jackson.databind.JsonMappingException
+import no.nav.bidrag.domene.ident.Personident
 
 class BeregningServiceValidationTest {
 
     private lateinit var validator: Validator
     private lateinit var objectMapper: ObjectMapper
+    private val personIdent = "12345678910"
 
     @BeforeEach
     fun setup() {
@@ -32,7 +34,7 @@ class BeregningServiceValidationTest {
             inntektForelder2 = 600000.0,
             barn = listOf(
                 BarnDto(
-                    alder = 12,
+                    ident = Personident(personIdent),
                     samværsklasse = Samværsklasse.SAMVÆRSKLASSE_1,
                     bidragstype = BidragsType.PLIKTIG
                 )
@@ -49,7 +51,7 @@ class BeregningServiceValidationTest {
                 "inntektForelder2": 600000.0,
                 "barn": [
                     {
-                        "alder": 12,
+                        "ident": "14429546002",
                         "samværsklasse": "SAMVÆRSKLASSE_1"
                     }
                 ]
@@ -79,7 +81,7 @@ class BeregningServiceValidationTest {
         val request = BeregningRequestDto(
             inntektForelder1 = -50000.0, // Ugyldig
             inntektForelder2 = 600000.0,
-            barn = listOf(BarnDto(8, Samværsklasse.SAMVÆRSKLASSE_1, BidragsType.PLIKTIG))
+            barn = listOf(BarnDto(Personident(personIdent), Samværsklasse.SAMVÆRSKLASSE_1, BidragsType.PLIKTIG))
         )
 
         val violations = validator.validate(request)
@@ -87,23 +89,11 @@ class BeregningServiceValidationTest {
     }
 
     @Test
-    fun `skal returnere valideringsfeil dersom barnets alder er utenfor gyldig intervall`() {
-        val request = BeregningRequestDto(
-            inntektForelder1 = 500000.0,
-            inntektForelder2 = 600000.0,
-            barn = listOf(BarnDto(30, Samværsklasse.SAMVÆRSKLASSE_1, BidragsType.PLIKTIG)) // Alder for høy
-        )
-
-        val violations = validator.validate(request)
-        assertTrue(violations.any { it.message.contains("Alder kan ikke være høyere enn 25") })
-    }
-
-    @Test
     fun `skal håndtere ekstremt høye inntekter korrekt`() {
         val request = BeregningRequestDto(
             inntektForelder1 = 1_000_000_000.0,  // 1 milliard
             inntektForelder2 = 900_000_000.0,  // 900 millioner
-            barn = listOf(BarnDto(12, Samværsklasse.SAMVÆRSKLASSE_1, BidragsType.MOTTAKER))
+            barn = listOf(BarnDto(Personident(personIdent), Samværsklasse.SAMVÆRSKLASSE_1, BidragsType.MOTTAKER))
         )
 
         val violations = validator.validate(request)

--- a/src/test/resources/testdata/barnebidrag/beregning_barn_over_18.json
+++ b/src/test/resources/testdata/barnebidrag/beregning_barn_over_18.json
@@ -3,7 +3,7 @@
   "inntektForelder2": 60000.0,
   "barn": [
     {
-      "alder": 19,
+      "ident": "06450659610",
       "samværsklasse": "SAMVÆRSKLASSE_4",
       "bidragstype": "PLIKTIG"
     }

--- a/src/test/resources/testdata/barnebidrag/beregning_et_barn.json
+++ b/src/test/resources/testdata/barnebidrag/beregning_et_barn.json
@@ -3,7 +3,7 @@
   "inntektForelder2": 60000.0,
   "barn": [
     {
-      "alder": 8,
+      "ident": "06451759610",
       "samværsklasse": "SAMVÆRSKLASSE_1",
       "bidragstype": "PLIKTIG"
     }

--- a/src/test/resources/testdata/barnebidrag/beregning_to_barn.json
+++ b/src/test/resources/testdata/barnebidrag/beregning_to_barn.json
@@ -3,12 +3,12 @@
   "inntektForelder2": 700000.0,
   "barn": [
     {
-      "alder": 10,
+      "ident": "06451759610",
       "samværsklasse": "SAMVÆRSKLASSE_1",
       "bidragstype": "PLIKTIG"
     },
     {
-      "alder": 6,
+      "ident": "26411966126",
       "samværsklasse": "SAMVÆRSKLASSE_1",
       "bidragstype": "PLIKTIG"
     }


### PR DESCRIPTION
Endre requestdto til å inkludere ident i stedet for alder. Identen ble brukt til å slå opp fødselsdato til barn som må sendes til beregning apiet