### PR TITLE
Legg til boforhold i beregning

### DIFF
--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/controller/BeregningController.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/controller/BeregningController.kt
@@ -9,6 +9,7 @@ import no.nav.bidrag.bidragskalkulator.dto.BeregningRequestDto
 import jakarta.validation.Valid
 import no.nav.bidrag.bidragskalkulator.config.SecurityConstants
 import no.nav.bidrag.bidragskalkulator.service.BeregningService
+import no.nav.bidrag.bidragskalkulator.validering.BeregningRequestValidator
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.web.bind.annotation.*
 
@@ -29,6 +30,7 @@ class BeregningController(private val beregningService: BeregningService) {
     )
     @PostMapping("/barnebidrag")
     fun beregnBarnebidragBeskyttet(@Valid @RequestBody request: BeregningRequestDto): BeregningsresultatDto {
+        BeregningRequestValidator.valider(request)
         return beregningService.beregnBarnebidrag(request)
     }
 }

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/BeregningRequestDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/BeregningRequestDto.kt
@@ -8,24 +8,24 @@ import jakarta.validation.constraints.Min
 import no.nav.bidrag.domene.enums.beregning.Samværsklasse
 import no.nav.bidrag.domene.ident.Personident
 
-@Schema(description = "Type bidrag")
+@Schema(description = "Angir hvilken rolle den påloggede personen har i bidragsberegningen")
 enum class BidragsType {
-    PLIKTIG,
-    MOTTAKER
+    PLIKTIG, // Pålogget person er bidragspliktig
+    MOTTAKER // Pålogget person er bidragsmottaker
 }
 
 @Schema(description = "Informasjon om et barn i beregningen")
 data class BarnDto(
-    @field:NotNull(message = "Unik identifikator for barnet")
-    @Schema(description = "Unik identifikator for barnet", required = true, example = "12345678901")
+    @field:NotNull(message = "Barnets identifikator må være satt")
+    @Schema(description = "Fødselsnummer eller D-nummer til barnet", required = true, example = "12345678901")
     val ident: Personident,
 
-    @field:NotNull(message = "samværsklasse må være satt")
+    @field:NotNull(message = "Samværsklasse må være satt")
     @Schema(ref = "#/components/schemas/Samværsklasse") // Reference dynamically registered schema. See BeregnBarnebidragConfig
     val samværsklasse: Samværsklasse,
 
-    @field:NotNull(message = "bidragstype må være satt")
-    @Schema(description = "Type bidrag", required = true)
+    @field:NotNull(message = "Bidragstype må være satt")
+    @Schema(description = "Angir om den påloggede personen er pliktig eller mottaker for dette barnet", required = true)
     val bidragstype: BidragsType
 )
 
@@ -44,5 +44,26 @@ data class BeregningRequestDto(
     @field:NotEmpty(message = "Liste over barn kan ikke være tom")
     @field:Valid
     @Schema(description = "Liste over barn som inngår i beregningen", required = true)
-    val barn: List<BarnDto>
+    val barn: List<BarnDto>,
+
+    @Schema(description = "Boforhold for den påloggede personen. Må være satt hvis bidragstype for barnet er PLIKTIG", required = false)
+    val dinBoforhold: BoforholdDto? = null,
+
+    @Schema(description = "Boforhold for den andre forelderen. Må være satt hvis bidragstype for barnet er MOTTAKER", required = false)
+    val medforelderBoforhold: BoforholdDto? = null,
+)
+
+@Schema(description = "Boforholdsinformasjon for en forelder, ekskludert barna som bor hos den andre forelderen")
+data class BoforholdDto(
+    @field:NotNull(message = "Antall barn som bor fast hos forelderen må være satt")
+    @Schema(description = "Antall barn under 18 år som bor fast hos forelderen, ekskludert barna som bor hos den andre forelderen", required = true, example = "3")
+    val antallBarnBorFast: Int,
+
+    @field:NotNull(message = "Antall barn som har avtalt delt bosted hos forelderen må være satt")
+    @Schema(description = "Antall barn under 18 år med delt bosted hos forelderen, ekskludert barna som bor hos den andre forelderen", required = true, example = "3")
+    val antallBarnDeltBosted: Int,
+
+    @field:NotNull(message = "Indikator om forelderen deler bolig med en annen voksen må være satt")
+    @Schema(description = "Indikerer om forelderen deler bolig med en annen voksen", required = true, example = "false")
+    val borMedAnnenVoksen: Boolean,
 )

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/BeregningRequestDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/BeregningRequestDto.kt
@@ -46,10 +46,10 @@ data class BeregningRequestDto(
     @Schema(description = "Liste over barn som inngår i beregningen", required = true)
     val barn: List<BarnDto>,
 
-    @Schema(description = "Boforhold for den påloggede personen. Må være satt hvis bidragstype for barnet er PLIKTIG", required = false)
+    @Schema(description = "Boforhold for den påloggede personen. Må være satt hvis bidragstype for minst ett barn er PLIKTIG", required = false)
     val dittBoforhold: BoforholdDto? = null,
 
-    @Schema(description = "Boforhold for den andre forelderen. Må være satt hvis bidragstype for barnet er MOTTAKER", required = false)
+    @Schema(description = "Boforhold for den andre forelderen. Må være satt hvis bidragstype for minst ett barn er MOTTAKER", required = false)
     val medforelderBoforhold: BoforholdDto? = null,
 )
 

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/BeregningRequestDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/BeregningRequestDto.kt
@@ -53,14 +53,14 @@ data class BeregningRequestDto(
     val medforelderBoforhold: BoforholdDto? = null,
 )
 
-@Schema(description = "Boforholdsinformasjon for en forelder, ekskludert barna som bor hos den andre forelderen")
+@Schema(description = "Boforholdsinformasjon for en forelder")
 data class BoforholdDto(
     @field:NotNull(message = "Antall barn som bor fast hos forelderen må være satt")
-    @Schema(description = "Antall barn under 18 år som bor fast hos forelderen, ekskludert barna som bor hos den andre forelderen", required = true, example = "3")
+    @Schema(description = "Antall barn under 18 år som bor fast hos forelderen", required = true, example = "3")
     val antallBarnBorFast: Int,
 
     @field:NotNull(message = "Antall barn som har avtalt delt bosted hos forelderen må være satt")
-    @Schema(description = "Antall barn under 18 år med delt bosted hos forelderen, ekskludert barna som bor hos den andre forelderen", required = true, example = "3")
+    @Schema(description = "Antall barn under 18 år med delt bosted hos forelderen", required = true, example = "3")
     val antallBarnDeltBosted: Int,
 
     @field:NotNull(message = "Indikator om forelderen deler bolig med en annen voksen må være satt")

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/BeregningRequestDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/BeregningRequestDto.kt
@@ -47,7 +47,7 @@ data class BeregningRequestDto(
     val barn: List<BarnDto>,
 
     @Schema(description = "Boforhold for den påloggede personen. Må være satt hvis bidragstype for barnet er PLIKTIG", required = false)
-    val dinBoforhold: BoforholdDto? = null,
+    val dittBoforhold: BoforholdDto? = null,
 
     @Schema(description = "Boforhold for den andre forelderen. Må være satt hvis bidragstype for barnet er MOTTAKER", required = false)
     val medforelderBoforhold: BoforholdDto? = null,

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/exception/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/exception/ApiExceptionHandler.kt
@@ -22,4 +22,11 @@ class ApiExceptionHandler {
     fun handleNoContentException(ex: NoContentException): ResponseEntity<Void> {
         return ResponseEntity.noContent().build()  // This returns a 204 No Content response
     }
+
+    // Handle the custom NoContentException and return a 400 Bad Request
+    @ExceptionHandler(UgyldigBeregningRequestException::class)
+    fun handleUgyldigBeregningRequestException(ex: UgyldigBeregningRequestException): ResponseEntity<Map<String, List<String>>> {
+        val errors = listOf(ex.message ?: "Ugyldig forespørsel")
+        return ResponseEntity(mapOf("errors" to errors), HttpStatus.BAD_REQUEST)
+    }
 }

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/exception/UgyldigBeregningRequestException.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/exception/UgyldigBeregningRequestException.kt
@@ -1,0 +1,7 @@
+package no.nav.bidrag.bidragskalkulator.exception
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+class UgyldigBeregningRequestException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagBuilder.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagBuilder.kt
@@ -1,0 +1,118 @@
+package no.nav.bidrag.bidragskalkulator.mapper
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import no.nav.bidrag.bidragskalkulator.dto.BarnDto
+import no.nav.bidrag.bidragskalkulator.mapper.BeregningsgrunnlagMapper.Referanser
+import no.nav.bidrag.domene.enums.grunnlag.Grunnlagstype
+import no.nav.bidrag.domene.enums.inntekt.Inntektsrapportering
+import no.nav.bidrag.domene.enums.person.Bostatuskode
+import no.nav.bidrag.domene.tid.ÅrMånedsperiode
+import no.nav.bidrag.transport.behandling.felles.grunnlag.*
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.YearMonth
+
+@Component
+class BeregningsgrunnlagBuilder(
+    private val objectMapper: ObjectMapper = ObjectMapper().registerKotlinModule().registerModule(JavaTimeModule())
+) {
+
+    fun byggPersongrunnlag(referanse: String, type: Grunnlagstype, fødselsdato: LocalDate? = null) = GrunnlagDto(
+        referanse = referanse,
+        type = type,
+        innhold = fødselsdato?.let { objectMapper.valueToTree(Person(fødselsdato = it)) }
+            ?: objectMapper.createObjectNode()
+    )
+
+    fun byggBostatusgrunnlag(data: Beregningskontekst): List<GrunnlagDto> {
+        fun nyttBostatusgrunnlag(referanse: String, bostatus: Bostatuskode, gjelderBarnReferanse: String?, gjelderReferanse: String? = null) =
+            GrunnlagDto(
+                referanse = referanse,
+                type = Grunnlagstype.BOSTATUS_PERIODE,
+                innhold = objectMapper.valueToTree(
+                    (gjelderReferanse ?: gjelderBarnReferanse)?.let {
+                        BostatusPeriode(
+                            bostatus = bostatus,
+                            periode = ÅrMånedsperiode(YearMonth.now(), null),
+                            relatertTilPart = it,
+                            manueltRegistrert = true
+                        )
+                    }
+                ),
+                gjelderBarnReferanse = gjelderBarnReferanse,
+                gjelderReferanse = gjelderReferanse
+            )
+
+        fun barnGrunnlag(antall: Int, prefix: String, kode: Bostatuskode) = List(antall) { index ->
+            nyttBostatusgrunnlag(
+                referanse = "Bostatus_${prefix}_$index",
+                bostatus = kode,
+                gjelderBarnReferanse = "Barn_${prefix}_$index",
+                gjelderReferanse = Referanser.BIDRAGSPLIKTIG
+            )
+        }
+
+        val boforhold = if (data.erBidragspliktig) data.dto.dinBoforhold else data.dto.medforelderBoforhold
+        val BPBostatus = if(boforhold?.borMedAnnenVoksen == true) Bostatuskode.BOR_MED_ANDRE_VOKSNE else Bostatuskode.ALENE
+
+        val bostatusBarn = buildList {
+            boforhold?.antallBarnBorFast?.takeIf { it > 0 }?.let {
+                addAll(barnGrunnlag(it, "med_forelder", Bostatuskode.MED_FORELDER))
+            }
+            boforhold?.antallBarnDeltBosted?.takeIf { it > 0 }?.let {
+                addAll(barnGrunnlag(it, "delt_bosted", Bostatuskode.DELT_BOSTED))
+            }
+        }
+
+        return buildList {
+            add(nyttBostatusgrunnlag("Bostatus_Bidragspliktig", BPBostatus, null, Referanser.BIDRAGSPLIKTIG))
+            add(nyttBostatusgrunnlag("Bostatus_${data.barnReferanse}", Bostatuskode.IKKE_MED_FORELDER, data.barnReferanse, Referanser.BIDRAGSPLIKTIG))
+            addAll(bostatusBarn)
+        }
+    }
+
+    fun byggInntektsgrunnlag(data: Beregningskontekst): List<GrunnlagDto> {
+        val lønnBidragsmottaker = if (data.erBidragspliktig) data.dto.inntektForelder2 else data.dto.inntektForelder1
+        val lønnBidragspliktig = if (data.erBidragspliktig) data.dto.inntektForelder1 else data.dto.inntektForelder2
+
+        fun nyttInntektsgrunnlag(referanse: String, beløp: BigDecimal, eierReferanse: String) =
+            GrunnlagDto(
+                referanse = referanse,
+                type = Grunnlagstype.INNTEKT_RAPPORTERING_PERIODE,
+                innhold = objectMapper.valueToTree(
+                    InntektsrapporteringPeriode(
+                        periode = ÅrMånedsperiode(YearMonth.now(), null),
+                        inntektsrapportering = Inntektsrapportering.SAKSBEHANDLER_BEREGNET_INNTEKT,
+                        beløp = beløp,
+                        manueltRegistrert = true,
+                        valgt = true
+                    )
+                ),
+                gjelderReferanse = eierReferanse
+            )
+
+        return listOf(
+            nyttInntektsgrunnlag("Inntekt_Bidragspliktig", lønnBidragspliktig.toBigDecimal(), Referanser.BIDRAGSPLIKTIG),
+            nyttInntektsgrunnlag("Inntekt_Bidragsmottaker", lønnBidragsmottaker.toBigDecimal(), Referanser.BIDRAGSMOTTAKER),
+            nyttInntektsgrunnlag("Inntekt_${data.barnReferanse}", BigDecimal.ZERO, data.barnReferanse)
+        )
+    }
+
+    fun byggSamværsgrunnlag(søknadsbarn: BarnDto, gjelderBarnReferanse: String): GrunnlagDto =
+        GrunnlagDto(
+            referanse = "Mottatt_Samværsperiode",
+            type = Grunnlagstype.SAMVÆRSPERIODE,
+            innhold = objectMapper.valueToTree(
+                SamværsperiodeGrunnlag(
+                    periode = ÅrMånedsperiode(YearMonth.now(), null),
+                    samværsklasse = søknadsbarn.samværsklasse,
+                    manueltRegistrert = true
+                )
+            ),
+            gjelderBarnReferanse = gjelderBarnReferanse,
+            gjelderReferanse = Referanser.BIDRAGSPLIKTIG
+        )
+}

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagBuilder.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagBuilder.kt
@@ -56,7 +56,7 @@ class BeregningsgrunnlagBuilder(
             )
         }
 
-        val boforhold = if (data.barn.bidragstype == BidragsType.PLIKTIG) data.dto.dinBoforhold else data.dto.medforelderBoforhold
+        val boforhold = if (data.barn.bidragstype == BidragsType.PLIKTIG) data.dto.dittBoforhold else data.dto.medforelderBoforhold
         val BPBostatus = if(boforhold?.borMedAnnenVoksen == true) Bostatuskode.BOR_MED_ANDRE_VOKSNE else Bostatuskode.BOR_IKKE_MED_ANDRE_VOKSNE
 
         val bostatusBarn = buildList {

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagBuilder.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagBuilder.kt
@@ -57,7 +57,7 @@ class BeregningsgrunnlagBuilder(
         }
 
         val boforhold = if (data.barn.bidragstype == BidragsType.PLIKTIG) data.dto.dittBoforhold else data.dto.medforelderBoforhold
-        val BPBostatus = if(boforhold?.borMedAnnenVoksen == true) Bostatuskode.BOR_MED_ANDRE_VOKSNE else Bostatuskode.BOR_IKKE_MED_ANDRE_VOKSNE
+        val bostatusBidragspliktig = if(boforhold?.borMedAnnenVoksen == true) Bostatuskode.BOR_MED_ANDRE_VOKSNE else Bostatuskode.BOR_IKKE_MED_ANDRE_VOKSNE
 
         val bostatusBarn = buildList {
             boforhold?.antallBarnBorFast?.takeIf { it > 0 }?.let {
@@ -69,7 +69,7 @@ class BeregningsgrunnlagBuilder(
         }
 
         return buildList {
-            add(nyttBostatusgrunnlag("Bostatus_Bidragspliktig", BPBostatus, null, Referanser.BIDRAGSPLIKTIG))
+            add(nyttBostatusgrunnlag("Bostatus_Bidragspliktig", bostatusBidragspliktig, null, Referanser.BIDRAGSPLIKTIG))
             add(nyttBostatusgrunnlag("Bostatus_${data.barnReferanse}", Bostatuskode.IKKE_MED_FORELDER, data.barnReferanse, Referanser.BIDRAGSPLIKTIG))
             addAll(bostatusBarn)
         }

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagBuilder.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagBuilder.kt
@@ -56,7 +56,7 @@ class BeregningsgrunnlagBuilder(
         }
 
         val boforhold = if (data.erBidragspliktig) data.dto.dinBoforhold else data.dto.medforelderBoforhold
-        val BPBostatus = if(boforhold?.borMedAnnenVoksen == true) Bostatuskode.BOR_MED_ANDRE_VOKSNE else Bostatuskode.ALENE
+        val BPBostatus = if(boforhold?.borMedAnnenVoksen == true) Bostatuskode.BOR_MED_ANDRE_VOKSNE else Bostatuskode.BOR_IKKE_MED_ANDRE_VOKSNE
 
         val bostatusBarn = buildList {
             boforhold?.antallBarnBorFast?.takeIf { it > 0 }?.let {

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagBuilder.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagBuilder.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import no.nav.bidrag.bidragskalkulator.dto.BarnDto
+import no.nav.bidrag.bidragskalkulator.dto.BidragsType
 import no.nav.bidrag.bidragskalkulator.mapper.BeregningsgrunnlagMapper.Referanser
 import no.nav.bidrag.domene.enums.grunnlag.Grunnlagstype
 import no.nav.bidrag.domene.enums.inntekt.Inntektsrapportering
@@ -55,7 +56,7 @@ class BeregningsgrunnlagBuilder(
             )
         }
 
-        val boforhold = if (data.erBidragspliktig) data.dto.dinBoforhold else data.dto.medforelderBoforhold
+        val boforhold = if (data.barn.bidragstype == BidragsType.PLIKTIG) data.dto.dinBoforhold else data.dto.medforelderBoforhold
         val BPBostatus = if(boforhold?.borMedAnnenVoksen == true) Bostatuskode.BOR_MED_ANDRE_VOKSNE else Bostatuskode.BOR_IKKE_MED_ANDRE_VOKSNE
 
         val bostatusBarn = buildList {
@@ -75,8 +76,9 @@ class BeregningsgrunnlagBuilder(
     }
 
     fun byggInntektsgrunnlag(data: Beregningskontekst): List<GrunnlagDto> {
-        val lønnBidragsmottaker = if (data.erBidragspliktig) data.dto.inntektForelder2 else data.dto.inntektForelder1
-        val lønnBidragspliktig = if (data.erBidragspliktig) data.dto.inntektForelder1 else data.dto.inntektForelder2
+        val erBidragspliktig = data.barn.bidragstype == BidragsType.PLIKTIG
+        val lønnBidragsmottaker = if (erBidragspliktig) data.dto.inntektForelder2 else data.dto.inntektForelder1
+        val lønnBidragspliktig = if (erBidragspliktig) data.dto.inntektForelder1 else data.dto.inntektForelder2
 
         fun nyttInntektsgrunnlag(referanse: String, beløp: BigDecimal, eierReferanse: String) =
             GrunnlagDto(

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapper.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapper.kt
@@ -53,7 +53,7 @@ class BeregningsgrunnlagMapper(private val personService: PersonService, private
         dto: BeregningRequestDto,
         barnReferanse: String
     ): List<GrunnlagDto> {
-        val kontekst = Beregningskontekst(dto, søknadsbarn, barnReferanse, søknadsbarn.bidragstype == BidragsType.PLIKTIG)
+        val kontekst = Beregningskontekst(dto, søknadsbarn, barnReferanse)
 
         return buildList{
             add(grunnlagBuilder.byggPersongrunnlag(Referanser.BIDRAGSMOTTAKER,Grunnlagstype.PERSON_BIDRAGSMOTTAKER))
@@ -79,5 +79,4 @@ data class Beregningskontekst(
     val dto: BeregningRequestDto,
     val barn: BarnDto,
     val barnReferanse: String,
-    val erBidragspliktig: Boolean
 )

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapper.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapper.kt
@@ -1,46 +1,33 @@
 package no.nav.bidrag.bidragskalkulator.mapper
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import no.nav.bidrag.bidragskalkulator.dto.BarnDto
-import no.nav.bidrag.bidragskalkulator.dto.BeregningRequestDto
-import no.nav.bidrag.bidragskalkulator.dto.BidragsType
+import no.nav.bidrag.bidragskalkulator.dto.*
 import no.nav.bidrag.bidragskalkulator.service.PersonService
 import no.nav.bidrag.bidragskalkulator.utils.kalkulereAlder
 import no.nav.bidrag.domene.enums.grunnlag.Grunnlagstype
-import no.nav.bidrag.domene.enums.inntekt.Inntektsrapportering
-import no.nav.bidrag.domene.enums.person.Bostatuskode
 import no.nav.bidrag.domene.enums.vedtak.Stønadstype
 import no.nav.bidrag.domene.ident.Personident
 import no.nav.bidrag.domene.tid.ÅrMånedsperiode
 import no.nav.bidrag.transport.behandling.beregning.felles.BeregnGrunnlag
 import no.nav.bidrag.transport.behandling.felles.grunnlag.*
 import org.springframework.stereotype.Component
-import java.math.BigDecimal
-import java.time.LocalDate
 import java.time.YearMonth
 
 @Component
-class BeregningsgrunnlagMapper(private val personService: PersonService) {
+class BeregningsgrunnlagMapper(private val personService: PersonService, private val grunnlagBuilder: BeregningsgrunnlagBuilder) {
 
-    companion object {
-        private const val BIDRAGSMOTTAKER_REFERANSE = "Person_Bidragsmottaker"
-        private const val BIDRAGSPLIKTIG_REFERANSE = "Person_Bidragspliktig"
-    }
-
-    private val objectMapper: ObjectMapper = ObjectMapper().apply {
-        registerKotlinModule()
-        registerModule(JavaTimeModule())
+    object Referanser {
+        const val BIDRAGSMOTTAKER = "Person_Bidragsmottaker"
+        const val BIDRAGSPLIKTIG = "Person_Bidragspliktig"
     }
 
     fun mapTilBeregningsgrunnlag(dto: BeregningRequestDto): List<GrunnlagOgBarnInformasjon> {
+
         val beregningsperiode = ÅrMånedsperiode(YearMonth.now(), YearMonth.now().plusMonths(1))
 
         return dto.barn.mapIndexed { index, søknadsbarn ->
             val barnetsInformasjon = personService.hentPersoninformasjon(søknadsbarn.ident)
             val barnetsAlder = kalkulereAlder(søknadsbarn.ident.fødselsdato())
-            val søknadsbarnReferanse = "Person_Søknadsbarn_$index"
+            val barnReferanse = "Person_Søknadsbarn_$index"
 
             GrunnlagOgBarnInformasjon(
                 ident = søknadsbarn.ident,
@@ -50,103 +37,33 @@ class BeregningsgrunnlagMapper(private val personService: PersonService) {
                 bidragsType = søknadsbarn.bidragstype,
                 grunnlag = BeregnGrunnlag(
                     periode = beregningsperiode,
-                    søknadsbarnReferanse = søknadsbarnReferanse,
-                    stønadstype = if(barnetsAlder >= 18) Stønadstype.BIDRAG18AAR else Stønadstype.BIDRAG,
-                    grunnlagListe = lagGrunnlagsliste(søknadsbarn,  dto, søknadsbarnReferanse)
+                    søknadsbarnReferanse = barnReferanse,
+                    stønadstype = when {
+                        barnetsAlder >= 18 -> Stønadstype.BIDRAG18AAR
+                        else -> Stønadstype.BIDRAG
+                    },
+                    grunnlagListe = lagGrunnlagsliste(søknadsbarn,  dto, barnReferanse)
                 )
             )
         }
     }
 
-    private fun lagGrunnlagsliste(søknadsbarn: BarnDto, dto: BeregningRequestDto, søknadsbarnReferanse: String): List<GrunnlagDto> {
-        val erBidragspliktig = søknadsbarn.bidragstype == BidragsType.PLIKTIG
-        val lønnBidragsmottaker = if (erBidragspliktig) dto.inntektForelder2 else dto.inntektForelder1
-        val lønnBidragspliktig = if (erBidragspliktig) dto.inntektForelder1 else dto.inntektForelder2
+    private fun lagGrunnlagsliste(
+        søknadsbarn: BarnDto,
+        dto: BeregningRequestDto,
+        barnReferanse: String
+    ): List<GrunnlagDto> {
+        val kontekst = Beregningskontekst(dto, søknadsbarn, barnReferanse, søknadsbarn.bidragstype == BidragsType.PLIKTIG)
 
-        return listOf(
-            lagTomtGrunnlag(BIDRAGSMOTTAKER_REFERANSE, Grunnlagstype.PERSON_BIDRAGSMOTTAKER),
-            lagTomtGrunnlag(BIDRAGSPLIKTIG_REFERANSE, Grunnlagstype.PERSON_BIDRAGSPLIKTIG),
-            lagBostatusgrunnlag("Bostatus_Bidragspliktig", Bostatuskode.BOR_MED_ANDRE_VOKSNE, null, BIDRAGSPLIKTIG_REFERANSE),
-            lagSøknadsbarngrunnlag(søknadsbarnReferanse, søknadsbarn.ident.fødselsdato()),
-            lagInntektsgrunnlag(
-                "Inntekt_Bidragspliktig",
-                lønnBidragspliktig.toBigDecimal(),
-                BIDRAGSPLIKTIG_REFERANSE
-            ),
-            lagInntektsgrunnlag(
-                "Inntekt_Bidragsmottaker",
-                lønnBidragsmottaker.toBigDecimal(),
-                BIDRAGSMOTTAKER_REFERANSE
-            ),
-            lagInntektsgrunnlag("Inntekt_$søknadsbarnReferanse", BigDecimal.ZERO, søknadsbarnReferanse),
-            lagBostatusgrunnlag(
-                "Bostatus_$søknadsbarnReferanse",
-                Bostatuskode.IKKE_MED_FORELDER,
-                søknadsbarnReferanse,
-                BIDRAGSPLIKTIG_REFERANSE
-            ),
-            lagSamværsgrunnlag(søknadsbarn, søknadsbarnReferanse, BIDRAGSPLIKTIG_REFERANSE)
-        )
+        return buildList{
+            add(grunnlagBuilder.byggPersongrunnlag(Referanser.BIDRAGSMOTTAKER,Grunnlagstype.PERSON_BIDRAGSMOTTAKER))
+            add(grunnlagBuilder.byggPersongrunnlag(Referanser.BIDRAGSPLIKTIG,Grunnlagstype.PERSON_BIDRAGSPLIKTIG))
+            add(grunnlagBuilder.byggPersongrunnlag(barnReferanse,Grunnlagstype.PERSON_SØKNADSBARN, søknadsbarn.ident.fødselsdato()))
+            addAll(grunnlagBuilder.byggInntektsgrunnlag(kontekst))
+            addAll(grunnlagBuilder.byggBostatusgrunnlag(kontekst))
+            add(grunnlagBuilder.byggSamværsgrunnlag(søknadsbarn, barnReferanse))
+        }
     }
-
-    private fun lagTomtGrunnlag(referanse: String, type: Grunnlagstype) =
-        GrunnlagDto(referanse, type, objectMapper.createObjectNode())
-
-    private fun lagSøknadsbarngrunnlag(søknadsbarnReferanse: String, søknadsbarnsfødselsdato: LocalDate) =
-        GrunnlagDto(
-            referanse = søknadsbarnReferanse,
-            type = Grunnlagstype.PERSON_SØKNADSBARN,
-            innhold = objectMapper.valueToTree(Person(fødselsdato = søknadsbarnsfødselsdato))
-        )
-
-    private fun lagInntektsgrunnlag(referanse: String, beløp: BigDecimal, eierReferanse: String) =
-        GrunnlagDto(
-            referanse = referanse,
-            type = Grunnlagstype.INNTEKT_RAPPORTERING_PERIODE,
-            innhold = objectMapper.valueToTree(
-                InntektsrapporteringPeriode(
-                    periode = ÅrMånedsperiode(YearMonth.now(), null),
-                    inntektsrapportering = Inntektsrapportering.SAKSBEHANDLER_BEREGNET_INNTEKT,
-                    beløp = beløp,
-                    manueltRegistrert = true,
-                    valgt = true
-                )
-            ),
-            gjelderReferanse = eierReferanse
-        )
-
-    private fun lagBostatusgrunnlag(referanse: String, bostatus: Bostatuskode, gjelderBarnReferanse: String?, gjelderReferanse: String? = null) =
-        GrunnlagDto(
-            referanse = referanse,
-            type = Grunnlagstype.BOSTATUS_PERIODE,
-            innhold = objectMapper.valueToTree(
-                (gjelderReferanse ?: gjelderBarnReferanse)?.let {
-                    BostatusPeriode(
-                        bostatus = bostatus,
-                        periode = ÅrMånedsperiode(YearMonth.now(), null),
-                        relatertTilPart = it,
-                        manueltRegistrert = true
-                    )
-                }
-            ),
-            gjelderBarnReferanse = gjelderBarnReferanse,
-            gjelderReferanse = gjelderReferanse
-        )
-
-    private fun lagSamværsgrunnlag(søknadsbarn: BarnDto, gjelderBarnReferanse: String, gjelderReferanse: String) =
-        GrunnlagDto(
-            referanse = "Mottatt_Samværsperiode",
-            type = Grunnlagstype.SAMVÆRSPERIODE,
-            innhold = objectMapper.valueToTree(
-                SamværsperiodeGrunnlag(
-                    periode = ÅrMånedsperiode(YearMonth.now(), null),
-                    samværsklasse = søknadsbarn.samværsklasse,
-                    manueltRegistrert = true
-                )
-            ),
-            gjelderBarnReferanse = gjelderBarnReferanse,
-            gjelderReferanse = gjelderReferanse
-        )
 }
 
 data class GrunnlagOgBarnInformasjon(
@@ -156,4 +73,11 @@ data class GrunnlagOgBarnInformasjon(
     val alder: Int,
     val bidragsType: BidragsType,
     val grunnlag: BeregnGrunnlag
+)
+
+data class Beregningskontekst(
+    val dto: BeregningRequestDto,
+    val barn: BarnDto,
+    val barnReferanse: String,
+    val erBidragspliktig: Boolean
 )

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/validering/BeregningRequestValidator.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/validering/BeregningRequestValidator.kt
@@ -1,0 +1,15 @@
+package no.nav.bidrag.bidragskalkulator.validering
+
+import no.nav.bidrag.bidragskalkulator.dto.BeregningRequestDto
+import no.nav.bidrag.bidragskalkulator.dto.BidragsType
+import no.nav.bidrag.bidragskalkulator.exception.UgyldigBeregningRequestException
+
+object BeregningRequestValidator {
+    fun valider(dto: BeregningRequestDto) {
+        val typer = dto.barn.map { it.bidragstype }.toSet()
+        require(!(typer.contains(BidragsType.PLIKTIG) && dto.dinBoforhold == null ||
+                typer.contains(BidragsType.MOTTAKER) && dto.medforelderBoforhold == null)) {
+            throw UgyldigBeregningRequestException("Boforhold må være satt når det finnes barn med bidragstype PLIKTIG eller MOTTAKER")
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/validering/BeregningRequestValidator.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/validering/BeregningRequestValidator.kt
@@ -10,14 +10,14 @@ object BeregningRequestValidator {
         val harPliktigeBarn = dto.barn.any { it.bidragstype == PLIKTIG }
         val harMottakerBarn = dto.barn.any { it.bidragstype == MOTTAKER }
 
-        val manglerDinBoforhold = harPliktigeBarn && dto.dinBoforhold == null
+        val manglerDinBoforhold = harPliktigeBarn && dto.dittBoforhold == null
         val manglerMedforelderBoforhold = harMottakerBarn && dto.medforelderBoforhold == null
 
         when {
             manglerDinBoforhold && manglerMedforelderBoforhold ->
-                feil("Både 'dinBoforhold' og 'medforelderBoforhold' mangler, men må være satt når forespørselen inneholder barn der du er bidragspliktig og/eller bidragsmottaker.")
+                feil("Både 'dittBoforhold' og 'medforelderBoforhold' mangler, men må være satt når forespørselen inneholder barn der du er bidragspliktig og/eller bidragsmottaker.")
             manglerDinBoforhold ->
-                feil("'dinBoforhold' må være satt fordi forespørselen inneholder minst ett barn der du er bidragspliktig.")
+                feil("'dittBoforhold' må være satt fordi forespørselen inneholder minst ett barn der du er bidragspliktig.")
             manglerMedforelderBoforhold ->
                 feil("'medforelderBoforhold' må være satt fordi forespørselen inneholder minst ett barn der du er bidragsmottaker.")
         }

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/validering/BeregningRequestValidator.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/validering/BeregningRequestValidator.kt
@@ -10,13 +10,13 @@ object BeregningRequestValidator {
         val harPliktigeBarn = dto.barn.any { it.bidragstype == PLIKTIG }
         val harMottakerBarn = dto.barn.any { it.bidragstype == MOTTAKER }
 
-        val manglerDinBoforhold = harPliktigeBarn && dto.dittBoforhold == null
+        val manglerDittBoforhold = harPliktigeBarn && dto.dittBoforhold == null
         val manglerMedforelderBoforhold = harMottakerBarn && dto.medforelderBoforhold == null
 
         when {
-            manglerDinBoforhold && manglerMedforelderBoforhold ->
+            manglerDittBoforhold && manglerMedforelderBoforhold ->
                 feil("Både 'dittBoforhold' og 'medforelderBoforhold' mangler, men må være satt når forespørselen inneholder barn der du er bidragspliktig og/eller bidragsmottaker.")
-            manglerDinBoforhold ->
+            manglerDittBoforhold ->
                 feil("'dittBoforhold' må være satt fordi forespørselen inneholder minst ett barn der du er bidragspliktig.")
             manglerMedforelderBoforhold ->
                 feil("'medforelderBoforhold' må være satt fordi forespørselen inneholder minst ett barn der du er bidragsmottaker.")

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/validering/BeregningRequestValidator.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/validering/BeregningRequestValidator.kt
@@ -1,15 +1,28 @@
 package no.nav.bidrag.bidragskalkulator.validering
 
 import no.nav.bidrag.bidragskalkulator.dto.BeregningRequestDto
-import no.nav.bidrag.bidragskalkulator.dto.BidragsType
+import no.nav.bidrag.bidragskalkulator.dto.BidragsType.*
 import no.nav.bidrag.bidragskalkulator.exception.UgyldigBeregningRequestException
 
 object BeregningRequestValidator {
+
     fun valider(dto: BeregningRequestDto) {
-        val typer = dto.barn.map { it.bidragstype }.toSet()
-        require(!(typer.contains(BidragsType.PLIKTIG) && dto.dinBoforhold == null ||
-                typer.contains(BidragsType.MOTTAKER) && dto.medforelderBoforhold == null)) {
-            throw UgyldigBeregningRequestException("Boforhold må være satt når det finnes barn med bidragstype PLIKTIG eller MOTTAKER")
+        val harPliktigeBarn = dto.barn.any { it.bidragstype == PLIKTIG }
+        val harMottakerBarn = dto.barn.any { it.bidragstype == MOTTAKER }
+
+        val manglerDinBoforhold = harPliktigeBarn && dto.dinBoforhold == null
+        val manglerMedforelderBoforhold = harMottakerBarn && dto.medforelderBoforhold == null
+
+        when {
+            manglerDinBoforhold && manglerMedforelderBoforhold ->
+                feil("Både 'dinBoforhold' og 'medforelderBoforhold' mangler, men må være satt når forespørselen inneholder barn der du er bidragspliktig og/eller bidragsmottaker.")
+            manglerDinBoforhold ->
+                feil("'dinBoforhold' må være satt fordi forespørselen inneholder minst ett barn der du er bidragspliktig.")
+            manglerMedforelderBoforhold ->
+                feil("'medforelderBoforhold' må være satt fordi forespørselen inneholder minst ett barn der du er bidragsmottaker.")
         }
     }
+
+    private fun feil(melding: String): Nothing =
+        throw UgyldigBeregningRequestException(melding)
 }

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/BeregningControllerTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/BeregningControllerTest.kt
@@ -63,12 +63,12 @@ class BeregningControllerTest: AbstractControllerTest() {
     }
 
     @Test
-    fun `skal returnere 400 hvis dinBoforhold mangler for PLIKTIG`() {
-        val ugyldigRequest = mockGyldigRequest.copy(dinBoforhold = null)
+    fun `skal returnere 400 hvis dittBoforhold mangler for PLIKTIG`() {
+        val ugyldigRequest = mockGyldigRequest.copy(dittBoforhold = null)
 
         postRequest("/api/v1/beregning/barnebidrag", ugyldigRequest, gyldigOAuth2Token)
             .andExpect(status().isBadRequest)
-            .andExpect(jsonPath("$.errors[0]").value("'dinBoforhold' må være satt fordi forespørselen inneholder minst ett barn der du er bidragspliktig."))
+            .andExpect(jsonPath("$.errors[0]").value("'dittBoforhold' må være satt fordi forespørselen inneholder minst ett barn der du er bidragspliktig."))
     }
 
     @Test
@@ -89,13 +89,13 @@ class BeregningControllerTest: AbstractControllerTest() {
                 BarnDto(ident = Personident(personIdent), samværsklasse = Samværsklasse.SAMVÆRSKLASSE_0, bidragstype = BidragsType.MOTTAKER),
                 BarnDto(ident = Personident(personIdent), samværsklasse = Samværsklasse.SAMVÆRSKLASSE_0, bidragstype = BidragsType.PLIKTIG)
                 ),
-            dinBoforhold = null,
+            dittBoforhold = null,
             medforelderBoforhold = null
         )
 
         postRequest("/api/v1/beregning/barnebidrag", ugyldigRequest, gyldigOAuth2Token)
             .andExpect(status().isBadRequest)
-            .andExpect(jsonPath("$.errors[0]").value("Både 'dinBoforhold' og 'medforelderBoforhold' mangler, men må være satt når forespørselen inneholder barn der du er bidragspliktig og/eller bidragsmottaker."))
+            .andExpect(jsonPath("$.errors[0]").value("Både 'dittBoforhold' og 'medforelderBoforhold' mangler, men må være satt når forespørselen inneholder barn der du er bidragspliktig og/eller bidragsmottaker."))
     }
 
     companion object TestData {
@@ -105,7 +105,7 @@ class BeregningControllerTest: AbstractControllerTest() {
             inntektForelder1 = 500000.0,
             inntektForelder2 = 400000.0,
             barn = listOf(BarnDto(ident = Personident(personIdent), samværsklasse = Samværsklasse.SAMVÆRSKLASSE_0, bidragstype = BidragsType.PLIKTIG)),
-            dinBoforhold = BoforholdDto(antallBarnBorFast = 0, antallBarnDeltBosted = 0, borMedAnnenVoksen = false)
+            dittBoforhold = BoforholdDto(antallBarnBorFast = 0, antallBarnDeltBosted = 0, borMedAnnenVoksen = false)
         )
 
         val mockRespons = BeregningsresultatDto(

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/BeregningControllerTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/BeregningControllerTest.kt
@@ -68,7 +68,7 @@ class BeregningControllerTest: AbstractControllerTest() {
 
         postRequest("/api/v1/beregning/barnebidrag", ugyldigRequest, gyldigOAuth2Token)
             .andExpect(status().isBadRequest)
-            .andExpect(jsonPath("$.errors[0]").value("Boforhold må være satt når det finnes barn med bidragstype PLIKTIG eller MOTTAKER"))
+            .andExpect(jsonPath("$.errors[0]").value("'dinBoforhold' må være satt fordi forespørselen inneholder minst ett barn der du er bidragspliktig."))
     }
 
     @Test
@@ -79,20 +79,23 @@ class BeregningControllerTest: AbstractControllerTest() {
 
         postRequest("/api/v1/beregning/barnebidrag", ugyldigRequest, gyldigOAuth2Token)
             .andExpect(status().isBadRequest)
-            .andExpect(jsonPath("$.errors[0]").value("Boforhold må være satt når det finnes barn med bidragstype PLIKTIG eller MOTTAKER"))
+            .andExpect(jsonPath("$.errors[0]").value("'medforelderBoforhold' må være satt fordi forespørselen inneholder minst ett barn der du er bidragsmottaker."))
     }
 
     @Test
     fun `skal returnere 400 hvis begge boforhold mangler`() {
         val ugyldigRequest = mockGyldigRequest.copy(
-            barn = listOf(BarnDto(ident = Personident(personIdent), samværsklasse = Samværsklasse.SAMVÆRSKLASSE_0, bidragstype = BidragsType.MOTTAKER)),
+            barn = listOf(
+                BarnDto(ident = Personident(personIdent), samværsklasse = Samværsklasse.SAMVÆRSKLASSE_0, bidragstype = BidragsType.MOTTAKER),
+                BarnDto(ident = Personident(personIdent), samværsklasse = Samværsklasse.SAMVÆRSKLASSE_0, bidragstype = BidragsType.PLIKTIG)
+                ),
             dinBoforhold = null,
             medforelderBoforhold = null
         )
 
         postRequest("/api/v1/beregning/barnebidrag", ugyldigRequest, gyldigOAuth2Token)
             .andExpect(status().isBadRequest)
-            .andExpect(jsonPath("$.errors[0]").value("Boforhold må være satt når det finnes barn med bidragstype PLIKTIG eller MOTTAKER"))
+            .andExpect(jsonPath("$.errors[0]").value("Både 'dinBoforhold' og 'medforelderBoforhold' mangler, men må være satt når forespørselen inneholder barn der du er bidragspliktig og/eller bidragsmottaker."))
     }
 
     companion object TestData {

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/BeregningControllerTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/BeregningControllerTest.kt
@@ -83,7 +83,7 @@ class BeregningControllerTest: AbstractControllerTest() {
     }
 
     @Test
-    fun `skal returnere 400 hvis begge boforhold mangler`() {
+    fun `skal returnere 400 hvis bruker er både bidragsmottaker og bidragspliktig, og begge boforhold mangler`() {
         val ugyldigRequest = mockGyldigRequest.copy(
             barn = listOf(
                 BarnDto(ident = Personident(personIdent), samværsklasse = Samværsklasse.SAMVÆRSKLASSE_0, bidragstype = BidragsType.MOTTAKER),
@@ -96,6 +96,21 @@ class BeregningControllerTest: AbstractControllerTest() {
         postRequest("/api/v1/beregning/barnebidrag", ugyldigRequest, gyldigOAuth2Token)
             .andExpect(status().isBadRequest)
             .andExpect(jsonPath("$.errors[0]").value("Både 'dittBoforhold' og 'medforelderBoforhold' mangler, men må være satt når forespørselen inneholder barn der du er bidragspliktig og/eller bidragsmottaker."))
+    }
+
+    @Test
+    fun `skal returnere 400 hvis bruker er både bidragsmottaker og bidragspliktig, og medforelderBoforhold mangler i forespørselen`() {
+        val ugyldigRequest = mockGyldigRequest.copy(
+            barn = listOf(
+                BarnDto(ident = Personident(personIdent), samværsklasse = Samværsklasse.SAMVÆRSKLASSE_0, bidragstype = BidragsType.MOTTAKER),
+                BarnDto(ident = Personident(personIdent), samværsklasse = Samværsklasse.SAMVÆRSKLASSE_0, bidragstype = BidragsType.PLIKTIG)
+                ),
+            medforelderBoforhold = null
+        )
+
+        postRequest("/api/v1/beregning/barnebidrag", ugyldigRequest, gyldigOAuth2Token)
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.errors[0]").value("'medforelderBoforhold' må være satt fordi forespørselen inneholder minst ett barn der du er bidragsmottaker."))
     }
 
     companion object TestData {

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagBuilderTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagBuilderTest.kt
@@ -1,0 +1,173 @@
+package no.nav.bidrag.bidragskalkulator.mapper
+
+import no.nav.bidrag.bidragskalkulator.dto.*
+import no.nav.bidrag.bidragskalkulator.utils.JsonUtils
+import no.nav.bidrag.domene.enums.grunnlag.Grunnlagstype
+import no.nav.bidrag.domene.enums.person.Bostatuskode
+import no.nav.bidrag.transport.behandling.felles.grunnlag.BostatusPeriode
+import no.nav.bidrag.transport.behandling.felles.grunnlag.innholdTilObjekt
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class BeregningsgrunnlagBuilderTest {
+
+    private val builder = BeregningsgrunnlagBuilder()
+
+    @Nested
+    inner class BostatusgrunnlagTest {
+
+        @Test
+        fun `skal bygge bostatusgrunnlag for bidragspliktig med barn som bor fast`() {
+            val beregningRequestMedBarnBorFast: BeregningRequestDto = JsonUtils.readJsonFile("/barnebidrag/beregning_et_barn.json")
+
+            val kontekst = lagKontekst(beregningRequestMedBarnBorFast, 0, "Person_Søknadsbarn_0")
+
+            val result = builder.byggBostatusgrunnlag(kontekst)
+
+            val barnBoFast = result.filter { it.referanse.startsWith("Bostatus_med_forelder_") }
+            val barnDeltBosted = result.filter { it.referanse.startsWith("Bostatus_delt_bosted_") }
+
+            assertThat(result).isNotEmpty
+            assertThat(barnBoFast).isNotEmpty
+            assertThat(barnDeltBosted).isNotEmpty
+            assertThat(result).anyMatch { it.referanse == "Bostatus_Bidragspliktig" }
+            // i beregningRequestDto har 2 barn som bor fast
+            assertThat(barnBoFast.size).isEqualTo(2)
+            // i beregningRequestDto har 1 barn med delt bosted
+            assertThat(barnDeltBosted.size).isEqualTo(1)
+        }
+
+        @Test
+        fun `skal bygge bostatusgrunnlag for bidragspliktig med delt bolig med annen voksen`() {
+            val beregningRequestDeltBolig: BeregningRequestDto = JsonUtils.readJsonFile("/barnebidrag/beregning_et_barn.json")
+
+            val kontekst = lagKontekst(beregningRequestDeltBolig, 0, "Person_Søknadsbarn_0")
+
+            val result = builder.byggBostatusgrunnlag(kontekst)
+            val deltBoligGrunnlag = result.find { it.type == Grunnlagstype.BOSTATUS_PERIODE }?.innholdTilObjekt<BostatusPeriode>()?.bostatus == Bostatuskode.BOR_MED_ANDRE_VOKSNE
+
+            assertThat(result).isNotEmpty
+            assertNotNull(deltBoligGrunnlag)
+            assertThat(result).anyMatch { it.referanse == "Bostatus_Bidragspliktig" }
+        }
+
+        @Test
+        fun `skal bygge bostatusgrunnlag for bidragspliktig som bor alene`() {
+            val beregningRequestBorIkkeMedAndreVoksne: BeregningRequestDto = JsonUtils.readJsonFile("/barnebidrag/beregning_to_barn.json")
+
+            val kontekst = lagKontekst(beregningRequestBorIkkeMedAndreVoksne, 0, "Person_Søknadsbarn_0")
+
+            val result = builder.byggBostatusgrunnlag(kontekst)
+            val borIkkeMedAndreVoksneGrunnlag = result
+                .find { it.innholdTilObjekt<BostatusPeriode>().bostatus == Bostatuskode.BOR_IKKE_MED_ANDRE_VOKSNE }
+
+            assertThat(result).isNotEmpty
+            assertNotNull(borIkkeMedAndreVoksneGrunnlag)
+            assertThat(result).anyMatch { it.referanse == "Bostatus_Bidragspliktig" }
+        }
+
+        @Test
+        fun `skal ikke lage grunnlag for barn i samme husstand hvis personen ikke har barn som bor fast`() {
+            val beregningRequestIngenBarnBorFast: BeregningRequestDto = JsonUtils.readJsonFile("/barnebidrag/beregning_to_barn.json")
+
+            val kontekst = lagKontekst(beregningRequestIngenBarnBorFast, 0, "Person_Søknadsbarn_0")
+
+            val result = builder.byggBostatusgrunnlag(kontekst)
+            val harBarnBorFast = result
+                .find { it.innholdTilObjekt<BostatusPeriode>().bostatus == Bostatuskode.MED_FORELDER }
+
+            assertNull(harBarnBorFast)
+        }
+
+        @Test
+        fun `skal bygge bostatusgrunnlag korrekt når samme person er både bidragspliktig og bidragsmottaker`() {
+            val request: BeregningRequestDto = JsonUtils.readJsonFile("/barnebidrag/beregning_person_er_baade_bp_og_bm.json")
+
+            val bostatusgrunnlagAlleBarn = request.barn.flatMapIndexed { index, barn ->
+                val kontekst = Beregningskontekst(
+                    dto = request,
+                    barn = barn,
+                    barnReferanse = "Person_Søknadsbarn_$index",
+                )
+
+                builder.byggBostatusgrunnlag(kontekst)
+            }
+
+            // Verifiser at vi har generert grunnlag for begge barn og at det finnes bostatus for bidragspliktig
+            val grunnlagReferanser = bostatusgrunnlagAlleBarn.map { it.referanse }
+
+            assertThat(bostatusgrunnlagAlleBarn).isNotEmpty
+            assertThat(grunnlagReferanser).anyMatch { it.contains("Bostatus_Bidragspliktig") }
+            assertThat(grunnlagReferanser).anyMatch { it.contains("Bostatus_Person_Søknadsbarn_0") }
+            assertThat(grunnlagReferanser).anyMatch { it.contains("Bostatus_Person_Søknadsbarn_1") }
+        }
+
+        @Test
+        fun `skal bruke dinBoforhold for bidragspliktig og medforelderBoforhold for bidragsmottaker`() {
+            val request: BeregningRequestDto = JsonUtils.readJsonFile("/barnebidrag/beregning_person_er_baade_bp_og_bm.json")
+
+            // barn indeks 0 = personen er bidragspliktig
+            val kontekstPliktig = lagKontekst(request, 0, "Person_Søknadsbarn_0")
+            // barn indeks 1 = personen er bidragsmottaker
+            val kontekstMottaker = lagKontekst(request, 1, "Person_Søknadsbarn_1")
+
+            val grunnlagPliktig = builder.byggBostatusgrunnlag(kontekstPliktig)
+            val grunnlagMottaker = builder.byggBostatusgrunnlag(kontekstMottaker)
+
+            val bostatusPliktig = grunnlagPliktig.filter { it.innholdTilObjekt<BostatusPeriode>().bostatus == Bostatuskode.MED_FORELDER }
+            val bostatusMottaker = grunnlagMottaker.filter { it.innholdTilObjekt<BostatusPeriode>().bostatus == Bostatuskode.MED_FORELDER }
+
+            assertThat(bostatusPliktig.size)
+                .withFailMessage("Forventet antall barn fra dinBoforhold å være ${request.dinBoforhold?.antallBarnBorFast}")
+                .isEqualTo(request.dinBoforhold?.antallBarnBorFast)
+
+            assertThat(bostatusMottaker.size)
+                .withFailMessage("Forventet antall barn fra medforelderBoforhold å være ${request.medforelderBoforhold?.antallBarnBorFast}")
+                .isEqualTo(request.medforelderBoforhold?.antallBarnBorFast)
+
+        }
+    }
+
+    @Nested
+    inner class InntektsgrunnlagTest {
+        @Test
+        fun `skal bygge inntektsgrunnlag med riktige beløp og referanser`() {
+            val beregningRequest: BeregningRequestDto = JsonUtils.readJsonFile("/barnebidrag/beregning_et_barn.json")
+            val kontekst = lagKontekst(beregningRequest, 0, "Person_Søknadsbarn_0")
+
+            val result = builder.byggInntektsgrunnlag(kontekst)
+
+            assertThat(result).hasSize(3)
+            assertThat(result).anyMatch { it.referanse == "Inntekt_Bidragspliktig" && it.gjelderReferanse == "Person_Bidragspliktig" }
+            assertThat(result).anyMatch { it.referanse == "Inntekt_Bidragsmottaker" && it.gjelderReferanse == "Person_Bidragsmottaker" }
+            assertThat(result).anyMatch { it.referanse == "Inntekt_Person_Søknadsbarn_0" && it.gjelderReferanse == "Person_Søknadsbarn_0" }
+        }
+    }
+
+    @Nested
+    inner class SamvaersgrunnlagTest {
+
+        @Test
+        fun `skal bygge samværsgrunnlag med korrekt klasse og referanser`() {
+            val beregningRequest: BeregningRequestDto = JsonUtils.readJsonFile("/barnebidrag/beregning_et_barn.json")
+
+            val result = builder.byggSamværsgrunnlag(beregningRequest.barn.first(), "Person_Søknadsbarn_0")
+
+            assertThat(result.type).isEqualTo(Grunnlagstype.SAMVÆRSPERIODE)
+            assertThat(result.gjelderReferanse).isEqualTo("Person_Bidragspliktig")
+            assertThat(result.gjelderBarnReferanse).isEqualTo("Person_Søknadsbarn_0")
+            assertThat(result.innhold["samværsklasse"].asText()).isEqualTo("SAMVÆRSKLASSE_1")
+        }
+    }
+
+    private fun lagKontekst(dto: BeregningRequestDto, barnIndex: Int, referanse: String): Beregningskontekst {
+        return Beregningskontekst(
+            dto = dto,
+            barn = dto.barn[barnIndex],
+            barnReferanse = referanse
+        )
+    }
+}

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagBuilderTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagBuilderTest.kt
@@ -106,7 +106,7 @@ class BeregningsgrunnlagBuilderTest {
         }
 
         @Test
-        fun `skal bruke dinBoforhold for bidragspliktig og medforelderBoforhold for bidragsmottaker`() {
+        fun `skal bruke dittBoforhold for bidragspliktig og medforelderBoforhold for bidragsmottaker`() {
             val request: BeregningRequestDto = JsonUtils.readJsonFile("/barnebidrag/beregning_person_er_baade_bp_og_bm.json")
 
             // barn indeks 0 = personen er bidragspliktig
@@ -121,8 +121,8 @@ class BeregningsgrunnlagBuilderTest {
             val bostatusMottaker = grunnlagMottaker.filter { it.innholdTilObjekt<BostatusPeriode>().bostatus == Bostatuskode.MED_FORELDER }
 
             assertThat(bostatusPliktig.size)
-                .withFailMessage("Forventet antall barn fra dinBoforhold å være ${request.dinBoforhold?.antallBarnBorFast}")
-                .isEqualTo(request.dinBoforhold?.antallBarnBorFast)
+                .withFailMessage("Forventet antall barn fra dittBoforhold å være ${request.dittBoforhold?.antallBarnBorFast}")
+                .isEqualTo(request.dittBoforhold?.antallBarnBorFast)
 
             assertThat(bostatusMottaker.size)
                 .withFailMessage("Forventet antall barn fra medforelderBoforhold å være ${request.medforelderBoforhold?.antallBarnBorFast}")

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapperTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapperTest.kt
@@ -20,6 +20,8 @@ class BeregningsgrunnlagMapperTest {
     @BeforeEach
     fun setup() {
         val mockPersonService = mockk<PersonService>(relaxed = true)
+        val mockBeregningsgrunnlagBuilder = mockk<BeregningsgrunnlagBuilder>(relaxed = true)
+
         val fødselsdato = LocalDate.now().minusYears(10)
 
         every { mockPersonService.hentPersoninformasjon(any()) } returns PersonDto(
@@ -29,7 +31,7 @@ class BeregningsgrunnlagMapperTest {
             visningsnavn = "Navn Navnesen",
         )
 
-        beregningsgrunnlagMapper = BeregningsgrunnlagMapper(mockPersonService)
+        beregningsgrunnlagMapper = BeregningsgrunnlagMapper(mockPersonService, mockBeregningsgrunnlagBuilder)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapperTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapperTest.kt
@@ -6,7 +6,6 @@ import io.mockk.junit5.MockKExtension
 import no.nav.bidrag.bidragskalkulator.dto.BeregningRequestDto
 import no.nav.bidrag.bidragskalkulator.service.PersonService
 import no.nav.bidrag.bidragskalkulator.utils.JsonUtils
-import no.nav.bidrag.domene.enums.grunnlag.Grunnlagstype
 import no.nav.bidrag.domene.enums.vedtak.Stønadstype
 import no.nav.bidrag.domene.ident.Personident
 import no.nav.bidrag.transport.person.PersonDto
@@ -65,7 +64,7 @@ class BeregningsgrunnlagMapperTest {
 
     @Test
     fun `skal ha riktig antall grunnlagselementer`() {
-        val beregningRequest: BeregningRequestDto = JsonUtils.readJsonFile("/barnebidrag/beregning_et_barn.json")
+        val beregningRequest: BeregningRequestDto = JsonUtils.readJsonFile("/barnebidrag/beregning_to_barn.json")
 
         val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlag(beregningRequest)
 
@@ -91,15 +90,6 @@ class BeregningsgrunnlagMapperTest {
         assertEquals(Stønadstype.BIDRAG, result.first().grunnlag.stønadstype)
     }
 
-    @Test
-    fun `skal ikke opprettes grunnlag for barn i samme husstand dersom personen ikke har barn som bor fast hos seg`() {
-        val beregningRequest: BeregningRequestDto = JsonUtils.readJsonFile("/barnebidrag/beregning_et_barn.json")
-        val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlag(beregningRequest)
-        val harBarnBorFast = result.first().grunnlag.grunnlagListe
-            .filter { it.type == Grunnlagstype.BOSTATUS_PERIODE }.map { it.referanse }.contains("Bostatus_med_forelder")
-
-        assertFalse(harBarnBorFast)
-    }
 
     private fun assertBarnetsAlderOgReferanse(
         grunnlagOgBarnInformasjon: GrunnlagOgBarnInformasjon,

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapperTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapperTest.kt
@@ -1,27 +1,34 @@
 package no.nav.bidrag.bidragskalkulator.mapper
 
 import io.mockk.every
-import io.mockk.mockk
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
 import no.nav.bidrag.bidragskalkulator.dto.BeregningRequestDto
 import no.nav.bidrag.bidragskalkulator.service.PersonService
 import no.nav.bidrag.bidragskalkulator.utils.JsonUtils
+import no.nav.bidrag.domene.enums.grunnlag.Grunnlagstype
 import no.nav.bidrag.domene.enums.vedtak.Stønadstype
 import no.nav.bidrag.domene.ident.Personident
 import no.nav.bidrag.transport.person.PersonDto
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import java.time.LocalDate
 
+@ExtendWith(MockKExtension::class)
 class BeregningsgrunnlagMapperTest {
+
+    @MockK(relaxed = true)
+    lateinit var mockPersonService: PersonService
+
+    // Bruk ekte builder
+    private val mockBeregningsgrunnlagBuilder = BeregningsgrunnlagBuilder()
 
     private lateinit var beregningsgrunnlagMapper: BeregningsgrunnlagMapper
 
     @BeforeEach
     fun setup() {
-        val mockPersonService = mockk<PersonService>(relaxed = true)
-        val mockBeregningsgrunnlagBuilder = mockk<BeregningsgrunnlagBuilder>(relaxed = true)
-
         val fødselsdato = LocalDate.now().minusYears(10)
 
         every { mockPersonService.hentPersoninformasjon(any()) } returns PersonDto(
@@ -76,13 +83,22 @@ class BeregningsgrunnlagMapperTest {
         assertEquals(Stønadstype.BIDRAG18AAR, result.first().grunnlag.stønadstype, "Stønadstype skal være BIDRAG18AAR for barn over 18")
     }
 
-
     @Test
     fun `skal sette stønadstype til BIDRAG for barn under 18`() {
         val beregningRequest: BeregningRequestDto = JsonUtils.readJsonFile("/barnebidrag/beregning_et_barn.json")
         val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlag(beregningRequest)
 
         assertEquals(Stønadstype.BIDRAG, result.first().grunnlag.stønadstype)
+    }
+
+    @Test
+    fun `skal ikke opprettes grunnlag for barn i samme husstand dersom personen ikke har barn som bor fast hos seg`() {
+        val beregningRequest: BeregningRequestDto = JsonUtils.readJsonFile("/barnebidrag/beregning_et_barn.json")
+        val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlag(beregningRequest)
+        val harBarnBorFast = result.first().grunnlag.grunnlagListe
+            .filter { it.type == Grunnlagstype.BOSTATUS_PERIODE }.map { it.referanse }.contains("Bostatus_med_forelder")
+
+        assertFalse(harBarnBorFast)
     }
 
     private fun assertBarnetsAlderOgReferanse(

--- a/src/test/resources/testdata/barnebidrag/beregning_barn_over_18.json
+++ b/src/test/resources/testdata/barnebidrag/beregning_barn_over_18.json
@@ -8,7 +8,7 @@
       "bidragstype": "PLIKTIG"
     }
   ],
-  "dinBoforhold": {
+  "dittBoforhold": {
     "antallBarnBorFast": 0,
     "antallBarnDeltBosted": 0,
     "borMedAnnenVoksen": false

--- a/src/test/resources/testdata/barnebidrag/beregning_barn_over_18.json
+++ b/src/test/resources/testdata/barnebidrag/beregning_barn_over_18.json
@@ -7,5 +7,10 @@
       "samværsklasse": "SAMVÆRSKLASSE_4",
       "bidragstype": "PLIKTIG"
     }
-  ]
+  ],
+  "dinBoforhold": {
+    "antallBarnBorFast": 0,
+    "antallBarnDeltBosted": 0,
+    "borMedAnnenVoksen": false
+  }
 }

--- a/src/test/resources/testdata/barnebidrag/beregning_et_barn.json
+++ b/src/test/resources/testdata/barnebidrag/beregning_et_barn.json
@@ -8,7 +8,7 @@
       "bidragstype": "PLIKTIG"
     }
   ],
-  "dinBoforhold": {
+  "dittBoforhold": {
     "antallBarnBorFast": 2,
     "antallBarnDeltBosted": 1,
     "borMedAnnenVoksen": true

--- a/src/test/resources/testdata/barnebidrag/beregning_et_barn.json
+++ b/src/test/resources/testdata/barnebidrag/beregning_et_barn.json
@@ -9,8 +9,8 @@
     }
   ],
   "dinBoforhold": {
-    "antallBarnBorFast": 0,
-    "antallBarnDeltBosted": 0,
-    "borMedAnnenVoksen": false
+    "antallBarnBorFast": 2,
+    "antallBarnDeltBosted": 1,
+    "borMedAnnenVoksen": true
   }
 }

--- a/src/test/resources/testdata/barnebidrag/beregning_et_barn.json
+++ b/src/test/resources/testdata/barnebidrag/beregning_et_barn.json
@@ -7,5 +7,10 @@
       "samværsklasse": "SAMVÆRSKLASSE_1",
       "bidragstype": "PLIKTIG"
     }
-  ]
+  ],
+  "dinBoforhold": {
+    "antallBarnBorFast": 0,
+    "antallBarnDeltBosted": 0,
+    "borMedAnnenVoksen": false
+  }
 }

--- a/src/test/resources/testdata/barnebidrag/beregning_person_er_baade_bp_og_bm.json
+++ b/src/test/resources/testdata/barnebidrag/beregning_person_er_baade_bp_og_bm.json
@@ -1,0 +1,26 @@
+{
+  "inntektForelder1": 400000.0,
+  "inntektForelder2": 900000.0,
+  "barn": [
+    {
+      "ident": "21501164140",
+      "samværsklasse": "SAMVÆRSKLASSE_0",
+      "bidragstype": "PLIKTIG"
+    },
+    {
+      "ident": "07471454529",
+      "samværsklasse": "SAMVÆRSKLASSE_0",
+      "bidragstype": "MOTTAKER"
+    }
+  ],
+  "dinBoforhold": {
+    "antallBarnBorFast": 3,
+    "antallBarnDeltBosted": 0,
+    "borMedAnnenVoksen": false
+  },
+  "medforelderBoforhold": {
+    "antallBarnBorFast": 1,
+    "antallBarnDeltBosted": 0,
+    "borMedAnnenVoksen": false
+  }
+}

--- a/src/test/resources/testdata/barnebidrag/beregning_person_er_baade_bp_og_bm.json
+++ b/src/test/resources/testdata/barnebidrag/beregning_person_er_baade_bp_og_bm.json
@@ -13,7 +13,7 @@
       "bidragstype": "MOTTAKER"
     }
   ],
-  "dinBoforhold": {
+  "dittBoforhold": {
     "antallBarnBorFast": 3,
     "antallBarnDeltBosted": 0,
     "borMedAnnenVoksen": false

--- a/src/test/resources/testdata/barnebidrag/beregning_to_barn.json
+++ b/src/test/resources/testdata/barnebidrag/beregning_to_barn.json
@@ -12,5 +12,10 @@
       "samværsklasse": "SAMVÆRSKLASSE_1",
       "bidragstype": "PLIKTIG"
     }
-  ]
+  ],
+  "dinBoforhold": {
+    "antallBarnBorFast": 0,
+    "antallBarnDeltBosted": 0,
+    "borMedAnnenVoksen": false
+  }
 }

--- a/src/test/resources/testdata/barnebidrag/beregning_to_barn.json
+++ b/src/test/resources/testdata/barnebidrag/beregning_to_barn.json
@@ -13,7 +13,7 @@
       "bidragstype": "PLIKTIG"
     }
   ],
-  "dinBoforhold": {
+  "dittBoforhold": {
     "antallBarnBorFast": 0,
     "antallBarnDeltBosted": 0,
     "borMedAnnenVoksen": false


### PR DESCRIPTION
- Lagt til feltene dinBoforhold og medforelderBoforhold i BeregningRequestDto.
- Disse feltene beskriver barnas (ikke barn du skal beregne barnebidrag for) bostedsform (f.eks. fast eller delt) hos hver av foreldrene. Dette er for å kunne generere korrekt beregningsgrunnlag i BeregningsgrunnlagMapper, må vi vite hvor mange barn som bor fast eller har delt bosted hos hver forelder. Denne informasjonen er nødvendig for å beregne riktige satser og fordeling av underholdskostnader.
