### PR TITLE
Legg til språk, vedlegg, andre bestemmelse og navskjemaId.

### DIFF
--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/config/SwaggerConfig.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/config/SwaggerConfig.kt
@@ -6,6 +6,11 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.media.Schema
+import no.nav.bidrag.bidragskalkulator.dto.AnnenDokumentasjon
+import no.nav.bidrag.bidragskalkulator.dto.Oppgjørsform
+import no.nav.bidrag.bidragskalkulator.dto.TilknyttetAvtaleVedlegg
+import no.nav.bidrag.bidragskalkulator.dto.foerstesidegenerator.NavSkjemaId
+import no.nav.bidrag.bidragskalkulator.dto.foerstesidegenerator.Språkkode
 import no.nav.bidrag.domene.enums.beregning.Samværsklasse
 import org.springdoc.core.customizers.OpenApiCustomizer
 import org.springframework.context.annotation.Bean
@@ -34,8 +39,48 @@ class SwaggerConfig {
                     enum = Samværsklasse.entries.map { it.name }
                 }
 
+            val oppgjørsformSchema = Schema<String>()
+                .description("Angir hvordan bidraget skal betales eller innkreves")
+                .example(Oppgjørsform.INNKREVING.name)
+                .apply {
+                    enum = Oppgjørsform.entries.map { it.name }
+                }
+
+            val tilknyttetAvtaleVedleggSchema = Schema<String>()
+                .description("Type vedlegg som er knyttet til avtalen")
+                .example(TilknyttetAvtaleVedlegg.SENDES_MED_SKJEMA.name)
+                .apply {
+                    enum = TilknyttetAvtaleVedlegg.entries.map { it.name }
+                }
+
+            val annenDokumentasjonSchema = Schema<String>()
+                .description("Tilleggsdokumentasjon som følger saken")
+                .example(AnnenDokumentasjon.INGEN_EKSTRA_DOKUMENTASJON.name)
+                .apply {
+                    enum = AnnenDokumentasjon.entries.map { it.name }
+                }
+
+            val språkkodeSchema = Schema<String>()
+                .description("Språkkode som angir hvilket språk dokumentet skal genereres på")
+                .example(Språkkode.NB.name)
+                .apply {
+                    enum = Språkkode.entries.map { it.name }
+                }
+
+            val navSkjemaIdSchema = Schema<String>()
+                .description("NAV-skjema som benyttes, identifisert ved skjema-ID")
+                .example(NavSkjemaId.AVTALE_OM_BARNEBIDRAG_UNDER_18.name)
+                .apply {
+                    enum = NavSkjemaId.entries.map { it.name }
+                }
+
             openApi.components = (openApi.components ?: Components())
                 .addSchemas("Samværsklasse", samværsklasseSchema)
+                .addSchemas("Oppgjørsform", oppgjørsformSchema)
+                .addSchemas("TilknyttetAvtaleVedlegg", tilknyttetAvtaleVedleggSchema)
+                .addSchemas("AnnenDokumentasjon", annenDokumentasjonSchema)
+                .addSchemas("Språkkode", språkkodeSchema)
+                .addSchemas("NavSkjemaId", navSkjemaIdSchema)
         }
     }
 }

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/consumer/FoerstesidegeneratorConsumer.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/consumer/FoerstesidegeneratorConsumer.kt
@@ -57,7 +57,7 @@ class FoerstesidegeneratorConsumer(
     fun genererFoersteside(dto: GenererFoerstesideRequestDto): GenererFoerstesideResultatDto =
         medApplikasjonsKontekst {
             val payload = FoerstesideDto(
-                språkkode = dto.språkkode,
+                spraakkode = dto.språkkode,
                 netsPostboks = "1400",
                 bruker = FoerstesideBrukerDto(
                     brukerId = dto.ident,

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/consumer/FoerstesidegeneratorConsumer.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/consumer/FoerstesidegeneratorConsumer.kt
@@ -57,7 +57,7 @@ class FoerstesidegeneratorConsumer(
     fun genererFoersteside(dto: GenererFoerstesideRequestDto): GenererFoerstesideResultatDto =
         medApplikasjonsKontekst {
             val payload = FoerstesideDto(
-                spraakkode = dto.spraakkode,
+                språkkode = dto.språkkode,
                 netsPostboks = "1400",
                 bruker = FoerstesideBrukerDto(
                     brukerId = dto.ident,

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/controller/MinSideController.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/controller/MinSideController.kt
@@ -1,20 +1,14 @@
 package no.nav.bidrag.bidragskalkulator.controller
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.slf4j.MDCContext
 import no.nav.bidrag.bidragskalkulator.config.SecurityConstants
 import no.nav.bidrag.bidragskalkulator.dto.minSide.MinSideDokumenterDto
 import no.nav.bidrag.bidragskalkulator.service.SafSelvbetjeningService
 import no.nav.bidrag.bidragskalkulator.utils.InnloggetBrukerUtils
-import no.nav.bidrag.commons.util.RequestContextAsyncContext
-import no.nav.bidrag.commons.util.SecurityCoroutineContext
 import no.nav.bidrag.commons.util.secureLogger
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
-import org.springframework.http.HttpStatusCode
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/controller/PrivatAvtaleController.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/controller/PrivatAvtaleController.kt
@@ -22,6 +22,7 @@ import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.context.annotation.Profile
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -80,10 +81,15 @@ class PrivatAvtaleController(
             ApiResponse(responseCode = "500", description = "Intern serverfeil")
         ]
     )
+    @Validated
     fun genererPrivatAvtale(@Valid @RequestBody privatAvtalePdfDto: PrivatAvtalePdfDto): ResponseEntity<ByteArray>? {
 
         val personIdent = innloggetBrukerUtils.hentPåloggetPersonIdent()
             ?: throw ResponseStatusException(HttpStatus.UNAUTHORIZED, "Ugyldig token")
+
+        if (privatAvtalePdfDto.andreBestemmelser.harAndreBestemmelser && privatAvtalePdfDto.andreBestemmelser.beskrivelse.isNullOrBlank()) {
+            throw IllegalArgumentException("Feltet 'andreBestemmelserTekst' er påkrevd når 'harAndreBestemmelser' er true.")
+        }
 
         val genererPrivatAvtalePdf =  privatAvtalePdfService.genererPrivatAvtalePdf(personIdent, privatAvtalePdfDto)
 

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdfDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdfDto.kt
@@ -122,10 +122,10 @@ enum class AnnenDokumentasjon {
 @Schema(description = "Skjema for vedlegg tilknyttet avtalen")
 data class Vedlegg(
     @field:NotNull
-    @param:Schema(description = "Hvordan dokumentasjonen knyttet til avtalen håndteres")
+    @param:Schema(ref = "#/components/schemas/TilknyttetAvtaleVedlegg")
     val tilknyttetAvtale: TilknyttetAvtaleVedlegg,
     @field:NotNull
-    @param:Schema(description = "Angir om annen dokumentasjon legges ved")
+    @param:Schema(ref = "#/components/schemas/AnnenDokumentasjon")
     val annenDokumentasjon: AnnenDokumentasjon
 )
 
@@ -140,9 +140,9 @@ data class AndreBestemmelserSkjema(
 
 @Schema(description = "Informasjon for generering av en privat avtale PDF")
 data class PrivatAvtalePdfDto(
-    @param:Schema(description = "Kode for skjematype ", required = true)
+    @param:Schema(ref = "#/components/schemas/NavSkjemaId", required = true)
     val navSkjemaId: NavSkjemaId,
-    @param:Schema(description = "Valgte språk", required = true)
+    @param:Schema(ref = "#/components/schemas/Språkkode", required = true)
     val språk: Språkkode,
     @param:Schema(description = "", required = true)
     val innhold: String,
@@ -154,7 +154,7 @@ data class PrivatAvtalePdfDto(
     val barn: List<PrivatAvtaleBarn>,
     @param:Schema(description = "Er dette en ny avtale?", required = true)
     val nyAvtale: Boolean,
-    @param:Schema(description = "Oppgjørsform for betaling av bidraget", required = true)
+    @param:Schema(ref = "#/components/schemas/Oppgjørsform", required = true)
     val oppgjorsform: Oppgjørsform,
     @param:Schema(description = "Er dette en avtale som skal sendes til NAV?", required = true)
     val tilInnsending: Boolean = false,

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdfDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdfDto.kt
@@ -6,6 +6,7 @@ import jakarta.validation.Valid
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
+import no.nav.bidrag.bidragskalkulator.dto.foerstesidegenerator.Språkkode
 import no.nav.bidrag.bidragskalkulator.utils.tilNorskDatoFormat
 
 interface PrivatAvtalePerson {
@@ -98,6 +99,8 @@ data class AndreBestemmelserSkjema(
 
 @Schema(description = "Informasjon for generering av en privat avtale PDF")
 data class PrivatAvtalePdfDto(
+    @param:Schema(description = "Valgte språk", required = true)
+    val språk: Språkkode,
     @param:Schema(description = "", required = true)
     val innhold: String,
     @param:Schema(description = "Informasjon om bidragsmottaker", required = true)

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdfDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdfDto.kt
@@ -2,8 +2,10 @@ package no.nav.bidrag.bidragskalkulator.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.Valid
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
 import no.nav.bidrag.bidragskalkulator.utils.tilNorskDatoFormat
 
 interface PrivatAvtalePerson {
@@ -11,64 +13,115 @@ interface PrivatAvtalePerson {
     val fodselsnummer: String
 }
 
+@Schema(description = "Representerer informasjon om bidragsmottaker i en privat avtale")
 data class PrivatAvtaleBidragsmottaker(
-    @field:NotEmpty(message = "fulltNavn må være satt")
-    @Schema(description = "Bidragsmottakers fulle navn", required = true)
+    @param:NotEmpty(message = FEILMELDING_NAVN)
+    @param:Schema(
+        description = "Bidragsmottakers fulle navn fra folkeregisteret",
+        required = true,
+        example = "Ola Nordmann"
+    )
     override val fulltNavn: String,
 
-    @field:NotEmpty(message = "Ident/fødselsnummer må være satt")
-    @Schema(description = "Bidragsmottakers fødselsnummer", required = true)
+    @param:NotEmpty(message = FEILMELDING_FODSELSNUMMER)
+    @param:Schema(
+        description = "Bidragsmottakers personnummer (11 siffer)",
+        required = true,
+        example = "12345678901"
+    )
     override val fodselsnummer: String,
-) : PrivatAvtalePerson
+) : PrivatAvtalePerson {
+    companion object {
+        private const val FEILMELDING_NAVN = "Navn må være utfylt"
+        private const val FEILMELDING_FODSELSNUMMER = "Gyldig fødselsnummer må være utfylt"
+    }
+}
 
 data class PrivatAvtaleBidragspliktig(
-    @field:NotEmpty(message = "fulltNavn må være satt")
-    @Schema(description = "Bidragsmottakers fulle navn", required = true)
+    @param:NotEmpty(message = "fulltNavn må være satt")
+    @param:Schema(description = "Bidragsmottakers fulle navn", required = true)
     override val fulltNavn: String,
 
-    @field:NotEmpty(message = "Ident/fødselsnummer må være satt")
-    @Schema(description = "Bidragsmottakers fødselsnummer", required = true)
+    @param:NotEmpty(message = "Ident/fødselsnummer må være satt")
+    @param:Schema(description = "Bidragsmottakers fødselsnummer", required = true)
     override val fodselsnummer: String,
 ) : PrivatAvtalePerson
 
 @Schema(description = "Informasjon om barnet i en privat avtale")
 data class PrivatAvtaleBarn(
-    @field:NotEmpty(message = "fulltNavn må være satt")
-    @Schema(description = "Bidragsmottakers fulle navn", required = true)
+    @param:NotEmpty(message = "fulltNavn må være satt")
+    @param:Schema(description = "Bidragsmottakers fulle navn", required = true)
     override val fulltNavn: String,
 
-    @field:NotEmpty(message = "Ident/fødselsnummer må være satt")
-    @Schema(description = "Bidragsmottakers fødselsnummer", required = true)
+    @param:NotEmpty(message = "Ident/fødselsnummer må være satt")
+    @param:Schema(description = "Bidragsmottakers fødselsnummer", required = true)
     override val fodselsnummer: String,
 
-    @field:Min(value = 1, message = "Bidraget må være større enn 0")
-    @Schema(description = "Barnets fødselsnummer", required = true)
+    @param:Min(value = 1, message = "Bidraget må være større enn 0")
+    @param:Schema(description = "Barnets fødselsnummer", required = true)
     val sumBidrag: Double  // Beløp in NOK
 ) : PrivatAvtalePerson
 
-// TODO: Definer oppgjørsformer som en enum (?)
-enum class Oppgjorsform {
-    // Add your enum values here
+enum class Oppgjørsform {
+    INNKREVING, PRIVAT
 }
+
+enum class TilknyttetAvtaleVedlegg {
+    SENDES_MED_SKJEMA,
+    ETTERSENDES,
+    LEVERT_TIDLIGERE
+}
+
+enum class AnnenDokumentasjon {
+    SENDES_MED_SKJEMA,
+    INGEN_EKSTRA_DOKUMENTASJON,
+}
+
+@Schema(description = "Skjema for vedlegg tilknyttet avtalen")
+data class Vedlegg(
+    @field:NotNull
+    @param:Schema(description = "Hvordan dokumentasjonen knyttet til avtalen håndteres")
+    val tilknyttetAvtale: TilknyttetAvtaleVedlegg,
+    @field:NotNull
+    @param:Schema(description = "Angir om annen dokumentasjon legges ved")
+    val annenDokumentasjon: AnnenDokumentasjon
+)
+
+
+@Schema(description = "Andre bestemmelser tilknyttet avtalen")
+data class AndreBestemmelserSkjema(
+    @param:Schema(description = "Angir om det er andre bestemmelser")
+    val harAndreBestemmelser: Boolean,
+    @param:Schema(description = "Tekstlig beskrivelse dersom andre bestemmelser er valgt")
+    val beskrivelse: String? = null
+)
 
 @Schema(description = "Informasjon for generering av en privat avtale PDF")
 data class PrivatAvtalePdfDto(
-    @Schema(description = "", required = true)
+    @param:Schema(description = "", required = true)
     val innhold: String,
-    @Schema(description = "Informasjon om bidragsmottaker", required = true)
+    @param:Schema(description = "Informasjon om bidragsmottaker", required = true)
     val bidragsmottaker: PrivatAvtaleBidragsmottaker,
-    @Schema(description = "Informasjon om bidragspliktig", required = true)
+    @param:Schema(description = "Informasjon om bidragspliktig", required = true)
     val bidragspliktig: PrivatAvtaleBidragspliktig,
-    @Schema(description = "Informasjon om barnet", required = true)
+    @param:Schema(description = "Informasjon om barnet", required = true)
     val barn: List<PrivatAvtaleBarn>,
-    @Schema(description = "Er dette en ny avtale?", required = true)
+    @param:Schema(description = "Er dette en ny avtale?", required = true)
     val nyAvtale: Boolean,
-    @Schema(description = "Oppgjørsform for betaling av bidraget", required = true)
-    val oppgjorsform: String,  // Consider using the Oppgjorsform enum instead of String
-    @Schema(description = "Er dette en avtale som skal sendes til NAV?", required = true)
+    @param:Schema(description = "Oppgjørsform for betaling av bidraget", required = true)
+    val oppgjorsform: Oppgjørsform,
+    @param:Schema(description = "Er dette en avtale som skal sendes til NAV?", required = true)
     val tilInnsending: Boolean = false,
-    @Schema(description = "Gjeldende dato for avtalen")
+    @param:Schema(description = "Gjeldende dato for avtalen")
     val fraDato: String,
+    @field:NotNull
+    @field:Valid
+    @param:Schema(description = "Vedlegg knyttet til avtalen")
+    val vedlegg: Vedlegg,
+    @field:NotNull
+    @field:Valid
+    @param:Schema(description = "Eventuelle andre bestemmelser som er inkludert i avtalen")
+    val andreBestemmelser: AndreBestemmelserSkjema
 )  {
     @JsonIgnore
     @Schema(hidden = true)

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdfDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdfDto.kt
@@ -144,8 +144,6 @@ data class PrivatAvtalePdfDto(
     val navSkjemaId: NavSkjemaId,
     @param:Schema(ref = "#/components/schemas/Språkkode", required = true)
     val språk: Språkkode,
-    @param:Schema(description = "", required = true)
-    val innhold: String,
     @param:Schema(description = "Informasjon om bidragsmottaker", required = true)
     val bidragsmottaker: PrivatAvtaleBidragsmottaker,
     @param:Schema(description = "Informasjon om bidragspliktig", required = true)

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdfDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdfDto.kt
@@ -6,23 +6,37 @@ import jakarta.validation.Valid
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
+import no.nav.bidrag.bidragskalkulator.dto.foerstesidegenerator.NavSkjemaId
 import no.nav.bidrag.bidragskalkulator.dto.foerstesidegenerator.Språkkode
 import no.nav.bidrag.bidragskalkulator.utils.tilNorskDatoFormat
 
+private const val FEILMELDING_FORNAVN = "Fornavn må være utfylt"
+private const val FEILMELDING_ETTERNAVN = "Etternavn må være utfylt"
+private const val FEILMELDING_FODSELSNUMMER = "Gyldig fødselsnummer må være utfylt"
+
 interface PrivatAvtalePerson {
-    val fulltNavn: String
+    val fornavn: String
+    val etternavn: String
     val fodselsnummer: String
 }
 
 @Schema(description = "Representerer informasjon om bidragsmottaker i en privat avtale")
 data class PrivatAvtaleBidragsmottaker(
-    @param:NotEmpty(message = FEILMELDING_NAVN)
+    @param:NotEmpty(message = FEILMELDING_FORNAVN)
     @param:Schema(
-        description = "Bidragsmottakers fulle navn fra folkeregisteret",
+        description = "Bidragsmottakers fornavn fra folkeregisteret",
         required = true,
-        example = "Ola Nordmann"
+        example = "Ola"
     )
-    override val fulltNavn: String,
+    override val fornavn: String,
+
+    @param:NotEmpty(message = FEILMELDING_ETTERNAVN)
+    @param:Schema(
+        description = "Bidragsmottakers etternavn fra folkeregisteret",
+        required = true,
+        example = "Nordmann"
+    )
+    override val etternavn: String,
 
     @param:NotEmpty(message = FEILMELDING_FODSELSNUMMER)
     @param:Schema(
@@ -31,31 +45,58 @@ data class PrivatAvtaleBidragsmottaker(
         example = "12345678901"
     )
     override val fodselsnummer: String,
-) : PrivatAvtalePerson {
-    companion object {
-        private const val FEILMELDING_NAVN = "Navn må være utfylt"
-        private const val FEILMELDING_FODSELSNUMMER = "Gyldig fødselsnummer må være utfylt"
-    }
-}
+) : PrivatAvtalePerson
 
 data class PrivatAvtaleBidragspliktig(
-    @param:NotEmpty(message = "fulltNavn må være satt")
-    @param:Schema(description = "Bidragsmottakers fulle navn", required = true)
-    override val fulltNavn: String,
+    @param:NotEmpty(message = FEILMELDING_FORNAVN)
+    @param:Schema(
+        description = "Bidragspliktig fornavn fra folkeregisteret",
+        required = true,
+        example = "Ola"
+    )
+    override val fornavn: String,
 
-    @param:NotEmpty(message = "Ident/fødselsnummer må være satt")
-    @param:Schema(description = "Bidragsmottakers fødselsnummer", required = true)
+    @param:NotEmpty(message = FEILMELDING_ETTERNAVN)
+    @param:Schema(
+        description = "Bidragspliktig etternavn fra folkeregisteret",
+        required = true,
+        example = "Nordmann"
+    )
+    override val etternavn: String,
+
+    @param:NotEmpty(message = FEILMELDING_FODSELSNUMMER)
+    @param:Schema(
+        description = "Bidragspliktig personnummer (11 siffer)",
+        required = true,
+        example = "12345678901"
+    )
     override val fodselsnummer: String,
 ) : PrivatAvtalePerson
 
 @Schema(description = "Informasjon om barnet i en privat avtale")
 data class PrivatAvtaleBarn(
-    @param:NotEmpty(message = "fulltNavn må være satt")
-    @param:Schema(description = "Bidragsmottakers fulle navn", required = true)
-    override val fulltNavn: String,
+    @param:NotEmpty(message = FEILMELDING_FORNAVN)
+    @param:Schema(
+        description = "Barn fornavn fra folkeregisteret",
+        required = true,
+        example = "Ola"
+    )
+    override val fornavn: String,
 
-    @param:NotEmpty(message = "Ident/fødselsnummer må være satt")
-    @param:Schema(description = "Bidragsmottakers fødselsnummer", required = true)
+    @param:NotEmpty(message = FEILMELDING_ETTERNAVN)
+    @param:Schema(
+        description = "Barn etternavn fra folkeregisteret",
+        required = true,
+        example = "Nordmann"
+    )
+    override val etternavn: String,
+
+    @param:NotEmpty(message = FEILMELDING_FODSELSNUMMER)
+    @param:Schema(
+        description = "Barn personnummer (11 siffer)",
+        required = true,
+        example = "12345678901"
+    )
     override val fodselsnummer: String,
 
     @param:Min(value = 1, message = "Bidraget må være større enn 0")
@@ -99,6 +140,8 @@ data class AndreBestemmelserSkjema(
 
 @Schema(description = "Informasjon for generering av en privat avtale PDF")
 data class PrivatAvtalePdfDto(
+    @param:Schema(description = "Kode for skjematype ", required = true)
+    val navSkjemaId: NavSkjemaId,
     @param:Schema(description = "Valgte språk", required = true)
     val språk: Språkkode,
     @param:Schema(description = "", required = true)

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdfDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdfDto.kt
@@ -1,8 +1,10 @@
 package no.nav.bidrag.bidragskalkulator.dto
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotEmpty
+import no.nav.bidrag.bidragskalkulator.utils.tilNorskDatoFormat
 
 interface PrivatAvtalePerson {
     val fulltNavn: String
@@ -59,12 +61,17 @@ data class PrivatAvtalePdfDto(
     val bidragspliktig: PrivatAvtaleBidragspliktig,
     @Schema(description = "Informasjon om barnet", required = true)
     val barn: List<PrivatAvtaleBarn>,
-    @Schema(description = "Gjeldende dato for avtalen")
-    val fraDato: String,
     @Schema(description = "Er dette en ny avtale?", required = true)
     val nyAvtale: Boolean,
     @Schema(description = "Oppgjørsform for betaling av bidraget", required = true)
     val oppgjorsform: String,  // Consider using the Oppgjorsform enum instead of String
     @Schema(description = "Er dette en avtale som skal sendes til NAV?", required = true)
-    val tilInnsending: Boolean = false
-)
+    val tilInnsending: Boolean = false,
+    @Schema(description = "Gjeldende dato for avtalen")
+    val fraDato: String,
+)  {
+    @JsonIgnore
+    @Schema(hidden = true)
+    fun tilNorskDatoFormat(): PrivatAvtalePdfDto =
+        this.copy(fraDato = fraDato.tilNorskDatoFormat())
+}

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/foerstesidegenerator/FoerstesidegeneratorDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/foerstesidegenerator/FoerstesidegeneratorDto.kt
@@ -2,7 +2,7 @@ package no.nav.bidrag.bidragskalkulator.dto.foerstesidegenerator
 
 
 data class FoerstesideDto(
-    val spraakkode: Spraakkode,
+    val språkkode: Språkkode,
     val bruker: FoerstesideBrukerDto,
     val tema: String,
     val overskriftstittel: String,
@@ -47,10 +47,10 @@ data class GenererFoerstesideRequestDto(
     val navSkjemaId: NavSkjemaId,
     val arkivtittel: String,
     val enhetsnummer: String,
-    val spraakkode: Spraakkode = Spraakkode.NB,
+    val språkkode: Språkkode = Språkkode.NB,
 )
 
-enum class Spraakkode {
+enum class Språkkode {
     NB, NN, EN
 }
 

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/foerstesidegenerator/FoerstesidegeneratorDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/foerstesidegenerator/FoerstesidegeneratorDto.kt
@@ -47,7 +47,7 @@ data class GenererFoerstesideRequestDto(
     val navSkjemaId: NavSkjemaId,
     val arkivtittel: String,
     val enhetsnummer: String,
-    val språkkode: Språkkode = Språkkode.NB,
+    val språkkode: Språkkode,
 )
 
 enum class Språkkode {
@@ -60,5 +60,5 @@ enum class Foerstesidetype {
 
 enum class NavSkjemaId(val kode: String) {
     AVTALE_OM_BARNEBIDRAG_UNDER_18("NAV 55-00.60"),
-    AVTALE_OM_BARNEBIDRAG_OVER_18("NAV 55-00.50"),
+    AVTALE_OM_BARNEBIDRAG_OVER_18("NAV 55-00.63"),
 }

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/foerstesidegenerator/FoerstesidegeneratorDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/foerstesidegenerator/FoerstesidegeneratorDto.kt
@@ -2,7 +2,7 @@ package no.nav.bidrag.bidragskalkulator.dto.foerstesidegenerator
 
 
 data class FoerstesideDto(
-    val språkkode: Språkkode,
+    val spraakkode: Språkkode,
     val bruker: FoerstesideBrukerDto,
     val tema: String,
     val overskriftstittel: String,

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/PrivatAvtalePdfService.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/PrivatAvtalePdfService.kt
@@ -5,6 +5,7 @@ import no.nav.bidrag.bidragskalkulator.consumer.FoerstesidegeneratorConsumer
 import no.nav.bidrag.bidragskalkulator.dto.PrivatAvtalePdfDto
 import no.nav.bidrag.bidragskalkulator.dto.foerstesidegenerator.GenererFoerstesideRequestDto
 import no.nav.bidrag.bidragskalkulator.dto.foerstesidegenerator.NavSkjemaId
+import no.nav.bidrag.bidragskalkulator.dto.foerstesidegenerator.Språkkode
 import no.nav.bidrag.bidragskalkulator.prosessor.PdfProsessor
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -38,7 +39,7 @@ class PrivatAvtalePdfService(
 
         if (privatAvtalePdfDto.tilInnsending) {
             val foersteside = measureTimedValue {
-                genererForsideForInnsending(innsenderIdent)
+                genererForsideForInnsending(innsenderIdent, privatAvtalePdfDto.språk)
             }.also {
                 logger.info("Førsteside generert på ${it.duration.inWholeMilliseconds} ms")
             }.value
@@ -53,13 +54,14 @@ class PrivatAvtalePdfService(
         }
     }
 
-    fun genererForsideForInnsending(navIdent: String): ByteArray =
+    fun genererForsideForInnsending(navIdent: String, språk: Språkkode): ByteArray =
         foerstesideConsumer.genererFoersteside(
             GenererFoerstesideRequestDto(
                 ident = navIdent,
                 navSkjemaId = NavSkjemaId.AVTALE_OM_BARNEBIDRAG_UNDER_18,
                 arkivtittel = "Avtale om barnebidrag",
-                enhetsnummer = "1234"
+                enhetsnummer = "1234",
+                språkkode = språk
             )
         ).foersteside
 

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/PrivatAvtalePdfService.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/PrivatAvtalePdfService.kt
@@ -29,7 +29,7 @@ class PrivatAvtalePdfService(
         logger.info("Starter generering av PDF for privat avtale")
 
         val hoveddokument = measureTimedValue {
-            bidragDokumentConsumer.genererPrivatAvtaleAPdf(privatAvtalePdfDto)
+            bidragDokumentConsumer.genererPrivatAvtaleAPdf(privatAvtalePdfDto.tilNorskDatoFormat())
         }.also {
             logger.info("Hoveddokument generert på ${it.duration.inWholeMilliseconds} ms")
         }.value

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/PrivatAvtalePdfService.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/PrivatAvtalePdfService.kt
@@ -39,7 +39,7 @@ class PrivatAvtalePdfService(
 
         if (privatAvtalePdfDto.tilInnsending) {
             val foersteside = measureTimedValue {
-                genererForsideForInnsending(innsenderIdent, privatAvtalePdfDto.språk)
+                genererForsideForInnsending(innsenderIdent, privatAvtalePdfDto)
             }.also {
                 logger.info("Førsteside generert på ${it.duration.inWholeMilliseconds} ms")
             }.value
@@ -54,14 +54,14 @@ class PrivatAvtalePdfService(
         }
     }
 
-    fun genererForsideForInnsending(navIdent: String, språk: Språkkode): ByteArray =
+    fun genererForsideForInnsending(navIdent: String, dto: PrivatAvtalePdfDto): ByteArray =
         foerstesideConsumer.genererFoersteside(
             GenererFoerstesideRequestDto(
                 ident = navIdent,
-                navSkjemaId = NavSkjemaId.AVTALE_OM_BARNEBIDRAG_UNDER_18,
+                navSkjemaId = dto.navSkjemaId,
                 arkivtittel = "Avtale om barnebidrag",
                 enhetsnummer = "1234",
-                språkkode = språk
+                språkkode = dto.språk
             )
         ).foersteside
 

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/utils/DateUtils.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/utils/DateUtils.kt
@@ -1,10 +1,11 @@
 package no.nav.bidrag.bidragskalkulator.utils
 
 
+import org.slf4j.LoggerFactory
 import java.time.LocalDate
 import java.time.Period
+import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
-import org.slf4j.LoggerFactory
 
 private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
@@ -14,5 +15,23 @@ fun kalkulerAlder(fødselsdato: LocalDate): Int {
     } catch (e: DateTimeParseException) {
         secureLogger.warn("Feil ved kalkulering av alder for fødselsdato $fødselsdato", e)
         0
+    }
+}
+
+fun String.tilNorskDatoFormat(): String {
+    return try {
+        // Forutsatt at inndataene er i formatet åååå-MM-dd eller dd.MM.åååå
+        val date = when {
+            this.contains("-") -> LocalDate.parse(this)
+            this.contains(".") -> LocalDate.parse(this, DateTimeFormatter.ofPattern("dd.MM.yyyy"))
+            else -> throw IllegalArgumentException("Ugyldig datoformat. Dato må være på format 'dd.MM.yyyy' eller 'yyyy-MM-dd'. Mottok: '$this'")
+        }
+
+        date.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))
+    } catch (e: DateTimeParseException) {
+        throw IllegalArgumentException(
+            "Kunne ikke konvertere '$this' til gyldig dato. Dato må være på format 'dd.MM.yyyy' eller 'yyyy-MM-dd",
+            e
+        )
     }
 }

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/service/PrivatAvtalePdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/service/PrivatAvtalePdfServiceTest.kt
@@ -34,8 +34,26 @@ class PrivatAvtalePdfServiceTest {
         every { mockFoerstesideConsumer.genererFoersteside(any()) } returns
                 GenererFoerstesideResultatDto(foersteside = forventetForside, loepenummer = "123")
 
+        val dto = PrivatAvtalePdfDto(
+            innhold = "Test",
+            bidragsmottaker = PrivatAvtaleBidragsmottaker("Mottaker", "Etternavnesen", "22222222222"),
+            bidragspliktig = PrivatAvtaleBidragspliktig("Pliktig", "Etternavnesen", "33333333333"),
+            barn = listOf(PrivatAvtaleBarn("Barn", "Etternavnesen", "11111111111", 1000.0)),
+            fraDato = "01.01.2023",
+            nyAvtale = true,
+            oppgjorsform = Oppgjørsform.INNKREVING,
+            tilInnsending = false,
+            språk = Språkkode.NB,
+            vedlegg = Vedlegg(
+                tilknyttetAvtale = TilknyttetAvtaleVedlegg.SENDES_MED_SKJEMA,
+                annenDokumentasjon = AnnenDokumentasjon.INGEN_EKSTRA_DOKUMENTASJON
+            ),
+            andreBestemmelser = AndreBestemmelserSkjema(harAndreBestemmelser = false),
+            navSkjemaId = NavSkjemaId.AVTALE_OM_BARNEBIDRAG_UNDER_18
+        )
+
         // Act
-        val faktiskForside = service.genererForsideForInnsending("12345678901")
+        val faktiskForside = service.genererForsideForInnsending("12345678901", dto)
 
         // Assert
         assertArrayEquals(forventetForside, faktiskForside)
@@ -54,13 +72,20 @@ class PrivatAvtalePdfServiceTest {
 
         val dto = PrivatAvtalePdfDto(
             innhold = "Test",
-            bidragsmottaker = PrivatAvtaleBidragsmottaker("Mottaker", "123"),
-            bidragspliktig = PrivatAvtaleBidragspliktig("Pliktig", "456"),
-            barn = listOf(PrivatAvtaleBarn("Barn", "789", 1000.0)),
+            bidragsmottaker = PrivatAvtaleBidragsmottaker("Mottaker", "Etternavnesen", "22222222222"),
+            bidragspliktig = PrivatAvtaleBidragspliktig("Pliktig", "Etternavnesen", "33333333333"),
+            barn = listOf(PrivatAvtaleBarn("Barn", "Etternavnesen", "11111111111", 1000.0)),
             fraDato = "01.01.2023",
             nyAvtale = true,
-            oppgjorsform = "Bank",
-            tilInnsending = false
+            oppgjorsform = Oppgjørsform.INNKREVING,
+            tilInnsending = false,
+            språk = Språkkode.NB,
+            vedlegg = Vedlegg(
+                tilknyttetAvtale = TilknyttetAvtaleVedlegg.SENDES_MED_SKJEMA,
+                annenDokumentasjon = AnnenDokumentasjon.INGEN_EKSTRA_DOKUMENTASJON
+            ),
+            andreBestemmelser = AndreBestemmelserSkjema(harAndreBestemmelser = false),
+            navSkjemaId = NavSkjemaId.AVTALE_OM_BARNEBIDRAG_UNDER_18
         )
 
         // Act

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/service/PrivatAvtalePdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/service/PrivatAvtalePdfServiceTest.kt
@@ -35,7 +35,6 @@ class PrivatAvtalePdfServiceTest {
                 GenererFoerstesideResultatDto(foersteside = forventetForside, loepenummer = "123")
 
         val dto = PrivatAvtalePdfDto(
-            innhold = "Test",
             bidragsmottaker = PrivatAvtaleBidragsmottaker("Mottaker", "Etternavnesen", "22222222222"),
             bidragspliktig = PrivatAvtaleBidragspliktig("Pliktig", "Etternavnesen", "33333333333"),
             barn = listOf(PrivatAvtaleBarn("Barn", "Etternavnesen", "11111111111", 1000.0)),
@@ -71,7 +70,6 @@ class PrivatAvtalePdfServiceTest {
         every { mockPdfProsessor.prosesserOgSlåSammenDokumenter(any()) } returns forventetKontrakt
 
         val dto = PrivatAvtalePdfDto(
-            innhold = "Test",
             bidragsmottaker = PrivatAvtaleBidragsmottaker("Mottaker", "Etternavnesen", "22222222222"),
             bidragspliktig = PrivatAvtaleBidragspliktig("Pliktig", "Etternavnesen", "33333333333"),
             barn = listOf(PrivatAvtaleBarn("Barn", "Etternavnesen", "11111111111", 1000.0)),


### PR DESCRIPTION
	•	Utvidet SwaggerConfig med nye skjemaer og oppdaterte referanser i PrivatAvtalePdfDto for bedre dokumentasjon og validering.
	•	Refaktorert genererForsideForInnsending til å bruke hele DTO-en i stedet for separate parametere.
	•	Lagt til støtte for språkindstilling ved generering av forsider, og oppdatert DTO-er med nye valideringsregler samt felter for fornavn og etternavn.
	•	Standardisert bruk av «språkkode» på tvers av DTO-er og enum-er, og introdusert et nytt felt for valgt språk i PrivatAvtalePdfDto.
	•	Introdusert nye enum-er, validering og vedleggshåndtering i PrivatAvtalePdfDto. Oppdatert den tilhørende metoden i kontrolleren for inputvalidering.
	•	Lagt til en metode for å formatere datoer til norsk format og fjernet ubrukt kode. Forbedret håndtering av fraDato i PrivatAvtalePdfDto og PrivatAvtalePdfService.