### PR TITLE
Update PrivatAvtalePdfDto and error handling for consistency

### DIFF
--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/config/SwaggerConfig.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/config/SwaggerConfig.kt
@@ -39,7 +39,9 @@ class SwaggerConfig {
                 }
 
             val oppgjørsformSchema = Schema<String>()
-                .description("Angir hvordan bidraget skal betales eller innkreves")
+                .description("Angir hvordan bidraget skal betales eller innkreves." +
+                        "PRIVATE = bidraget gjøres opp privat, " +
+                        "NAV_INNKREVING = bidraget betales via Skatteetaten/NAV Innkreving.")
                 .example(Oppgjørsform.INNKREVING.name)
                 .apply {
                     enum = Oppgjørsform.entries.map { it.name }

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/config/SwaggerConfig.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/config/SwaggerConfig.kt
@@ -6,9 +6,8 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.media.Schema
-import no.nav.bidrag.bidragskalkulator.dto.AnnenDokumentasjon
 import no.nav.bidrag.bidragskalkulator.dto.Oppgjørsform
-import no.nav.bidrag.bidragskalkulator.dto.TilknyttetAvtaleVedlegg
+import no.nav.bidrag.bidragskalkulator.dto.Vedleggskrav
 import no.nav.bidrag.bidragskalkulator.dto.foerstesidegenerator.NavSkjemaId
 import no.nav.bidrag.bidragskalkulator.dto.foerstesidegenerator.Språkkode
 import no.nav.bidrag.domene.enums.beregning.Samværsklasse
@@ -46,18 +45,11 @@ class SwaggerConfig {
                     enum = Oppgjørsform.entries.map { it.name }
                 }
 
-            val tilknyttetAvtaleVedleggSchema = Schema<String>()
-                .description("Type vedlegg som er knyttet til avtalen")
-                .example(TilknyttetAvtaleVedlegg.SENDES_MED_SKJEMA.name)
-                .apply {
-                    enum = TilknyttetAvtaleVedlegg.entries.map { it.name }
-                }
-
-            val annenDokumentasjonSchema = Schema<String>()
+            val vedleggskravSchema = Schema<String>()
                 .description("Tilleggsdokumentasjon som følger saken")
-                .example(AnnenDokumentasjon.INGEN_EKSTRA_DOKUMENTASJON.name)
+                .example(Vedleggskrav.INGEN_EKSTRA_DOKUMENTASJON.name)
                 .apply {
-                    enum = AnnenDokumentasjon.entries.map { it.name }
+                    enum = Vedleggskrav.entries.map { it.name }
                 }
 
             val språkkodeSchema = Schema<String>()
@@ -77,8 +69,7 @@ class SwaggerConfig {
             openApi.components = (openApi.components ?: Components())
                 .addSchemas("Samværsklasse", samværsklasseSchema)
                 .addSchemas("Oppgjørsform", oppgjørsformSchema)
-                .addSchemas("TilknyttetAvtaleVedlegg", tilknyttetAvtaleVedleggSchema)
-                .addSchemas("AnnenDokumentasjon", annenDokumentasjonSchema)
+                .addSchemas("Vedleggskrav", vedleggskravSchema)
                 .addSchemas("Språkkode", språkkodeSchema)
                 .addSchemas("NavSkjemaId", navSkjemaIdSchema)
         }

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/controller/PersonController.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/controller/PersonController.kt
@@ -38,6 +38,7 @@ class PersonController(
         value = [
             ApiResponse(responseCode = "200", description = "Brukerinformasjon hentet vellykket"),
             ApiResponse(responseCode = "204", description = "Person eksisterer ikke"),
+            ApiResponse(responseCode = "400", description = "Ugyldig forespørsel – valideringsfeil eller ugyldig enumverdi"),
             ApiResponse(responseCode = "401", description = "Uautorisert tilgang - ugyldig eller utløpt token"),
             ApiResponse(responseCode = "500", description = "Intern serverfeil")
         ]

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/controller/PrivatAvtaleController.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/controller/PrivatAvtaleController.kt
@@ -91,6 +91,10 @@ class PrivatAvtaleController(
             throw IllegalArgumentException("Feltet 'andreBestemmelserTekst' er påkrevd når 'harAndreBestemmelser' er true.")
         }
 
+        if (!privatAvtalePdfDto.oppgjør.nyAvtale && privatAvtalePdfDto.oppgjør.oppgjørsformIdag == null) {
+            throw IllegalArgumentException("Feltet 'oppgjørsformIdag' er påkrevd når det er eksisterende avtale.")
+        }
+
         val genererPrivatAvtalePdf =  privatAvtalePdfService.genererPrivatAvtalePdf(personIdent, privatAvtalePdfDto)
 
         val privatAvtaleByteArray = genererPrivatAvtalePdf.toByteArray()

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/controller/PrivatAvtaleController.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/controller/PrivatAvtaleController.kt
@@ -50,7 +50,8 @@ class PrivatAvtaleController(
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "Privat avtale informasjon hentet vellykket"),
-            ApiResponse(responseCode = "401", description = "Uautorisert tilgang - mangler eller ugyldig token"),
+            ApiResponse(responseCode = "400", description = "Ugyldig forespørsel – valideringsfeil eller ugyldig enumverdi"),
+            ApiResponse(responseCode = "401", description = "Uautorisert tilgang – mangler eller ugyldig token"),
             ApiResponse(responseCode = "500", description = "Intern serverfeil")
         ]
     )
@@ -78,6 +79,8 @@ class PrivatAvtaleController(
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "Privat avtale PDF generert"),
+            ApiResponse(responseCode = "400", description = "Ugyldig forespørsel – valideringsfeil eller ugyldig enumverdi"),
+            ApiResponse(responseCode = "401", description = "Uautorisert tilgang – mangler eller ugyldig token"),
             ApiResponse(responseCode = "500", description = "Intern serverfeil")
         ]
     )

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtaleInformasjonDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtaleInformasjonDto.kt
@@ -4,5 +4,6 @@ import no.nav.bidrag.domene.ident.Personident
 
 data class PrivatAvtaleInformasjonDto (
     val ident: Personident,
-    val fulltNavn: String,
+    val fornavn: String,
+    val etternavn: String,
 )

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdfDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdfDto.kt
@@ -108,27 +108,10 @@ enum class Oppgjørsform {
     INNKREVING, PRIVAT
 }
 
-enum class TilknyttetAvtaleVedlegg {
-    SENDES_MED_SKJEMA,
-    ETTERSENDES,
-    LEVERT_TIDLIGERE
-}
-
-enum class AnnenDokumentasjon {
+enum class Vedleggskrav {
     SENDES_MED_SKJEMA,
     INGEN_EKSTRA_DOKUMENTASJON,
 }
-
-@Schema(description = "Skjema for vedlegg tilknyttet avtalen")
-data class Vedlegg(
-    @field:NotNull
-    @param:Schema(ref = "#/components/schemas/TilknyttetAvtaleVedlegg")
-    val tilknyttetAvtale: TilknyttetAvtaleVedlegg,
-    @field:NotNull
-    @param:Schema(ref = "#/components/schemas/AnnenDokumentasjon")
-    val annenDokumentasjon: AnnenDokumentasjon
-)
-
 
 @Schema(description = "Andre bestemmelser tilknyttet avtalen")
 data class AndreBestemmelserSkjema(
@@ -158,10 +141,10 @@ data class PrivatAvtalePdfDto(
     val tilInnsending: Boolean = false,
     @param:Schema(description = "Gjeldende dato for avtalen")
     val fraDato: String,
-    @field:NotNull
     @field:Valid
-    @param:Schema(description = "Vedlegg knyttet til avtalen")
-    val vedlegg: Vedlegg,
+    @field:NotNull
+    @param:Schema(ref = "#/components/schemas/Vedleggskrav")
+    val vedlegg: Vedleggskrav,
     @field:NotNull
     @field:Valid
     @param:Schema(description = "Eventuelle andre bestemmelser som er inkludert i avtalen")

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdfDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdfDto.kt
@@ -101,7 +101,10 @@ data class PrivatAvtaleBarn(
 
     @param:Min(value = 1, message = "Bidraget må være større enn 0")
     @param:Schema(description = "Barnets fødselsnummer", required = true)
-    val sumBidrag: Double  // Beløp in NOK
+    val sumBidrag: Double,  // Beløp in NOK
+
+    @param:Schema(description = "Gjeldende dato for avtalen", required = true, example = "2022-01-01")
+    val fraDato: String,
 ) : PrivatAvtalePerson
 
 enum class Oppgjørsform {
@@ -144,9 +147,6 @@ data class PrivatAvtalePdfDto(
     @field:NotNull
     val oppgjør: Oppgjør,
 
-    @param:Schema(description = "Gjeldende dato for avtalen")
-    val fraDato: String,
-
     @field:Valid
     @field:NotNull
     @param:Schema(ref = "#/components/schemas/Vedleggskrav")
@@ -159,8 +159,9 @@ data class PrivatAvtalePdfDto(
 )  {
     @JsonIgnore
     @Schema(hidden = true)
-    fun tilNorskDatoFormat(): PrivatAvtalePdfDto =
-        this.copy(fraDato = fraDato.tilNorskDatoFormat())
+    fun medNorskeDatoer(): PrivatAvtalePdfDto = this.copy(
+        barn = this.barn.map { it.copy(fraDato = it.fraDato.tilNorskDatoFormat()) },
+    )
 }
 
 @Schema(

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdfDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdfDto.kt
@@ -17,7 +17,7 @@ private const val FEILMELDING_FODSELSNUMMER = "Gyldig fødselsnummer må være u
 interface PrivatAvtalePerson {
     val fornavn: String
     val etternavn: String
-    val fodselsnummer: String
+    val ident: String
 }
 
 @Schema(description = "Representerer informasjon om bidragsmottaker i en privat avtale")
@@ -44,7 +44,7 @@ data class PrivatAvtaleBidragsmottaker(
         required = true,
         example = "12345678901"
     )
-    override val fodselsnummer: String,
+    override val ident: String,
 ) : PrivatAvtalePerson
 
 data class PrivatAvtaleBidragspliktig(
@@ -70,7 +70,7 @@ data class PrivatAvtaleBidragspliktig(
         required = true,
         example = "12345678901"
     )
-    override val fodselsnummer: String,
+    override val ident: String,
 ) : PrivatAvtalePerson
 
 @Schema(description = "Informasjon om barnet i en privat avtale")
@@ -97,7 +97,7 @@ data class PrivatAvtaleBarn(
         required = true,
         example = "12345678901"
     )
-    override val fodselsnummer: String,
+    override val ident: String,
 
     @param:Min(value = 1, message = "Bidraget må være større enn 0")
     @param:Schema(description = "Barnets fødselsnummer", required = true)

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,91 @@
+package no.nav.bidrag.bidragskalkulator.exception
+
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.exc.InvalidFormatException
+import jakarta.validation.ConstraintViolationException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+
+@ControllerAdvice
+class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun handleIllegalArgument(e: IllegalArgumentException): ProblemDetail =
+        ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, e.message ?: "Ugyldig forespørsel").apply {
+            title = "Bad Request"
+        }
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleMethodArgumentNotValid(e: MethodArgumentNotValidException): ProblemDetail {
+        val firstError = e.bindingResult.fieldErrors.firstOrNull()
+        val detail = if (firstError != null) {
+            "${firstError.field}: ${firstError.defaultMessage}"
+        } else {
+            "Valideringsfeil i request body"
+        }
+        return ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, detail).apply {
+            title = "Bad Request"
+        }
+    }
+
+    @ExceptionHandler(ConstraintViolationException::class)
+    fun handleConstraintViolation(e: ConstraintViolationException): ProblemDetail {
+        val detail = e.constraintViolations.firstOrNull()?.let { v ->
+            "${v.propertyPath}: ${v.message}"
+        } ?: "Valideringsfeil i parametre"
+        return ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, detail).apply {
+            title = "Bad Request"
+        }
+    }
+
+    /**
+     * Gjelder typisk feil enum-verdi i JSON body (Jackson deserialisering).
+     */
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun handleHttpMessageNotReadable(e: HttpMessageNotReadableException): ProblemDetail {
+        val cause = e.cause
+        if (cause is InvalidFormatException) {
+            val target = cause.targetType
+            if (target.isEnum) {
+                val field = cause.path.lastOrNull()?.let(JsonMappingException.Reference::getFieldName) ?: "ukjent felt"
+                val provided = cause.value?.toString() ?: "null"
+                val allowed = target.enumConstants.joinToString(", ") { (it as Enum<*>).name }
+                val detail = "Ugyldig verdi '$provided' for felt '$field'. Tillatte verdier: $allowed."
+                return ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, detail).apply {
+                    title = "Bad Request"
+                }
+            }
+        }
+        // Fallback for andre parse-feil
+        return ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "Ugyldig request body (kunne ikke tolkes).").apply {
+            title = "Bad Request"
+        }
+    }
+
+    /**
+     * Gjelder typisk feil enum-verdi i query/path-parametre.
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+    fun handleMethodArgumentTypeMismatch(e: MethodArgumentTypeMismatchException): ProblemDetail {
+        val required = e.requiredType
+        if (required != null && required.isEnum) {
+            val field = e.name
+            val provided = e.value?.toString() ?: "null"
+            val allowed = required.enumConstants.joinToString(", ") { (it as Enum<*>).name }
+            val detail = "Ugyldig verdi '$provided' for parameter '$field'. Tillatte verdier: $allowed."
+            return ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, detail).apply {
+                title = "Bad Request"
+            }
+        }
+        val detail = "Ugyldig verdi for parameter '${e.name}'. Forventet type: ${required?.simpleName ?: "ukjent"}."
+        return ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, detail).apply {
+            title = "Bad Request"
+        }
+    }
+
+}

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/PersonDtoMapper.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/PersonDtoMapper.kt
@@ -26,7 +26,8 @@ fun PersonDto.tilBarnInformasjonDto(underholdskostnad: BigDecimal?): BarnInforma
 fun PersonDto.tilPrivatAvtaleInformasjonDto(): PrivatAvtaleInformasjonDto =
     PrivatAvtaleInformasjonDto(
         ident = this.ident,
-        fulltNavn = this.visningsnavn,
+        fornavn = this.fornavn ?: "-",
+        etternavn = this.etternavn ?: "-",
     )
 
 fun PersonDto.erLevendeOgIkkeSkjermet(): Boolean =

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/PrivatAvtalePdfService.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/PrivatAvtalePdfService.kt
@@ -4,8 +4,6 @@ import no.nav.bidrag.bidragskalkulator.consumer.BidragDokumentProduksjonConsumer
 import no.nav.bidrag.bidragskalkulator.consumer.FoerstesidegeneratorConsumer
 import no.nav.bidrag.bidragskalkulator.dto.PrivatAvtalePdfDto
 import no.nav.bidrag.bidragskalkulator.dto.foerstesidegenerator.GenererFoerstesideRequestDto
-import no.nav.bidrag.bidragskalkulator.dto.foerstesidegenerator.NavSkjemaId
-import no.nav.bidrag.bidragskalkulator.dto.foerstesidegenerator.Språkkode
 import no.nav.bidrag.bidragskalkulator.prosessor.PdfProsessor
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/PrivatAvtalePdfService.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/PrivatAvtalePdfService.kt
@@ -29,7 +29,7 @@ class PrivatAvtalePdfService(
         logger.info("Starter generering av PDF for privat avtale")
 
         val hoveddokument = measureTimedValue {
-            bidragDokumentConsumer.genererPrivatAvtaleAPdf(privatAvtalePdfDto.tilNorskDatoFormat())
+            bidragDokumentConsumer.genererPrivatAvtaleAPdf(privatAvtalePdfDto.medNorskeDatoer())
         }.also {
             logger.info("Hoveddokument generert på ${it.duration.inWholeMilliseconds} ms")
         }.value

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/PrivatAvtalePdfService.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/PrivatAvtalePdfService.kt
@@ -3,6 +3,7 @@ package no.nav.bidrag.bidragskalkulator.service
 import no.nav.bidrag.bidragskalkulator.consumer.BidragDokumentProduksjonConsumer
 import no.nav.bidrag.bidragskalkulator.consumer.FoerstesidegeneratorConsumer
 import no.nav.bidrag.bidragskalkulator.dto.PrivatAvtalePdfDto
+import no.nav.bidrag.bidragskalkulator.dto.erOppgjørsformEndret
 import no.nav.bidrag.bidragskalkulator.dto.foerstesidegenerator.GenererFoerstesideRequestDto
 import no.nav.bidrag.bidragskalkulator.prosessor.PdfProsessor
 import org.slf4j.LoggerFactory
@@ -35,7 +36,7 @@ class PrivatAvtalePdfService(
 
         val dokumenter = mutableListOf(hoveddokument.toByteArray())
 
-        if (privatAvtalePdfDto.tilInnsending) {
+        if (privatAvtalePdfDto.oppgjør.erOppgjørsformEndret()) {
             val foersteside = measureTimedValue {
                 genererForsideForInnsending(innsenderIdent, privatAvtalePdfDto)
             }.also {

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/PrivatAvtaleControllerTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/PrivatAvtaleControllerTest.kt
@@ -2,17 +2,32 @@ package no.nav.bidrag.bidragskalkulator.controller
 
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
+import io.mockk.verify
+import no.nav.bidrag.bidragskalkulator.dto.AndreBestemmelserSkjema
+import no.nav.bidrag.bidragskalkulator.dto.Oppgjør
+import no.nav.bidrag.bidragskalkulator.dto.Oppgjørsform
+import no.nav.bidrag.bidragskalkulator.dto.PrivatAvtaleBarn
+import no.nav.bidrag.bidragskalkulator.dto.PrivatAvtaleBidragsmottaker
+import no.nav.bidrag.bidragskalkulator.dto.PrivatAvtaleBidragspliktig
+import no.nav.bidrag.bidragskalkulator.dto.PrivatAvtalePdfDto
+import no.nav.bidrag.bidragskalkulator.dto.Vedleggskrav
+import no.nav.bidrag.bidragskalkulator.dto.foerstesidegenerator.NavSkjemaId
+import no.nav.bidrag.bidragskalkulator.dto.foerstesidegenerator.Språkkode
 import no.nav.bidrag.bidragskalkulator.mapper.tilPrivatAvtaleInformasjonDto
+import no.nav.bidrag.bidragskalkulator.service.PrivatAvtalePdfService
 import no.nav.bidrag.bidragskalkulator.service.PrivatAvtaleService
 import no.nav.bidrag.bidragskalkulator.utils.InnloggetBrukerUtils
 import no.nav.bidrag.bidragskalkulator.utils.JsonUtils
 import no.nav.bidrag.transport.person.MotpartBarnRelasjonDto
+import org.springframework.http.MediaType.APPLICATION_PDF
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 import kotlin.test.Test
 
 class PrivatAvtaleControllerTest: AbstractControllerTest() {
     @MockkBean
     private lateinit var privatAvtaleService: PrivatAvtaleService
+    @MockkBean
+    private lateinit var privatAvtalePdfService: PrivatAvtalePdfService
     @MockkBean
     private lateinit var innloggetBrukerUtils: InnloggetBrukerUtils
 
@@ -42,5 +57,75 @@ class PrivatAvtaleControllerTest: AbstractControllerTest() {
         getRequest("/api/v1/privat-avtale/informasjon", gyldigOAuth2Token)
             .andExpect(status().isUnauthorized)
             .andExpect(jsonPath("$.error").value("Ugyldig token"))
+    }
+
+    @Test
+    fun `skal generere privat avtale PDF`() {
+        val personIdent = "12345678910"
+        val dto = lagGyldigPrivatAvtalePdfDto()
+
+        every { innloggetBrukerUtils.hentPåloggetPersonIdent() } returns personIdent
+
+        every { privatAvtalePdfService.genererPrivatAvtalePdf(personIdent, dto) } returns
+                java.io.ByteArrayOutputStream().apply {
+                    // Minimal PDF-like bytes: "%PDF-1.4\n%%EOF"
+                    write(byteArrayOf(0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x34, 0x0A, 0x25, 0x25, 0x45, 0x4F, 0x46))
+                }
+
+        postRequest(
+            "/api/v1/privat-avtale",
+            dto,
+            gyldigOAuth2Token
+        )
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(APPLICATION_PDF))
+            .andExpect(header().string("Content-Disposition", "inline; filename=\"privatavtale.pdf\""))
+    }
+
+    @Test
+    fun `skal gi feil hvis harAndreBestemmelser er true men beskrivelse mangler`() {
+        val dto = lagGyldigPrivatAvtalePdfDto().copy(
+            andreBestemmelser = AndreBestemmelserSkjema(harAndreBestemmelser = true, beskrivelse = null)
+        )
+        val personIdent = "12345678910"
+
+        every { innloggetBrukerUtils.hentPåloggetPersonIdent() } returns personIdent
+
+        verify(exactly = 0) { privatAvtalePdfService.genererPrivatAvtalePdf(personIdent, any()) }
+
+        postRequest("/api/v1/privat-avtale", dto, gyldigOAuth2Token)
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.detail").value("Feltet 'andreBestemmelserTekst' er påkrevd når 'harAndreBestemmelser' er true."))
+    }
+
+    @Test
+    fun `skal gi feil hvis nyAvtale er false og oppgjorsformIdag er null`() {
+        val dto = lagGyldigPrivatAvtalePdfDto().copy(
+            oppgjør = Oppgjør(nyAvtale = false, oppgjørsformØnsket = Oppgjørsform.INNKREVING, oppgjørsformIdag = null)
+        )
+        val personIdent = "12345678910"
+
+        every { innloggetBrukerUtils.hentPåloggetPersonIdent() } returns personIdent
+
+        verify(exactly = 0) { privatAvtalePdfService.genererPrivatAvtalePdf(personIdent, any()) }
+
+        postRequest("/api/v1/privat-avtale", dto, gyldigOAuth2Token)
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.detail").value("Feltet 'oppgjørsformIdag' er påkrevd når det er eksisterende avtale."))
+    }
+
+
+    private fun lagGyldigPrivatAvtalePdfDto(): PrivatAvtalePdfDto {
+        return PrivatAvtalePdfDto(
+            navSkjemaId = NavSkjemaId.AVTALE_OM_BARNEBIDRAG_UNDER_18,
+            språk = Språkkode.NB,
+            bidragsmottaker = PrivatAvtaleBidragsmottaker("Ola", "Nordmann", "12345678901"),
+            bidragspliktig = PrivatAvtaleBidragspliktig("Kari", "Nordmann", "10987654321"),
+            barn = listOf(PrivatAvtaleBarn("Barn", "Nordmann", "01010112345", 1000.0)),
+            oppgjør = Oppgjør(nyAvtale = true, oppgjørsformØnsket = Oppgjørsform.INNKREVING),
+            fraDato = "2025-01-01",
+            vedlegg = Vedleggskrav.INGEN_EKSTRA_DOKUMENTASJON,
+            andreBestemmelser = AndreBestemmelserSkjema(false, null)
+        )
     }
 }

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/PrivatAvtaleControllerTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/PrivatAvtaleControllerTest.kt
@@ -121,9 +121,8 @@ class PrivatAvtaleControllerTest: AbstractControllerTest() {
             språk = Språkkode.NB,
             bidragsmottaker = PrivatAvtaleBidragsmottaker("Ola", "Nordmann", "12345678901"),
             bidragspliktig = PrivatAvtaleBidragspliktig("Kari", "Nordmann", "10987654321"),
-            barn = listOf(PrivatAvtaleBarn("Barn", "Nordmann", "01010112345", 1000.0)),
+            barn = listOf(PrivatAvtaleBarn("Barn", "Nordmann", "01010112345", 1000.0, fraDato = "2025-01-01")),
             oppgjør = Oppgjør(nyAvtale = true, oppgjørsformØnsket = Oppgjørsform.INNKREVING),
-            fraDato = "2025-01-01",
             vedlegg = Vedleggskrav.INGEN_EKSTRA_DOKUMENTASJON,
             andreBestemmelser = AndreBestemmelserSkjema(false, null)
         )

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/PrivatAvtaleControllerTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/PrivatAvtaleControllerTest.kt
@@ -29,7 +29,8 @@ class PrivatAvtaleControllerTest: AbstractControllerTest() {
 
         getRequest("/api/v1/privat-avtale/informasjon", gyldigOAuth2Token)
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.fulltNavn").value(forventetDto.fulltNavn))
+            .andExpect(jsonPath("$.fornavn").value(forventetDto.fornavn))
+            .andExpect(jsonPath("$.etternavn").value(forventetDto.etternavn))
             .andExpect(jsonPath("$.ident").value(forventetDto.ident.verdi))
     }
 

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/service/PrivatAvtalePdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/service/PrivatAvtalePdfServiceTest.kt
@@ -37,8 +37,7 @@ class PrivatAvtalePdfServiceTest {
         val dto = PrivatAvtalePdfDto(
             bidragsmottaker = PrivatAvtaleBidragsmottaker("Mottaker", "Etternavnesen", "22222222222"),
             bidragspliktig = PrivatAvtaleBidragspliktig("Pliktig", "Etternavnesen", "33333333333"),
-            barn = listOf(PrivatAvtaleBarn("Barn", "Etternavnesen", "11111111111", 1000.0)),
-            fraDato = "01.01.2023",
+            barn = listOf(PrivatAvtaleBarn("Barn", "Etternavnesen", "11111111111", 1000.0, fraDato = "2025-01-01")),
             oppgjør = Oppgjør(
                 nyAvtale = true,
                 oppgjørsformØnsket = Oppgjørsform.INNKREVING,
@@ -71,8 +70,7 @@ class PrivatAvtalePdfServiceTest {
         val dto = PrivatAvtalePdfDto(
             bidragsmottaker = PrivatAvtaleBidragsmottaker("Mottaker", "Etternavnesen", "22222222222"),
             bidragspliktig = PrivatAvtaleBidragspliktig("Pliktig", "Etternavnesen", "33333333333"),
-            barn = listOf(PrivatAvtaleBarn("Barn", "Etternavnesen", "11111111111", 1000.0)),
-            fraDato = "01.01.2023",
+            barn = listOf(PrivatAvtaleBarn("Barn", "Etternavnesen", "11111111111", 1000.0, fraDato = "2025-01-01")),
             oppgjør = Oppgjør(
                 nyAvtale = true,
                 oppgjørsformØnsket = Oppgjørsform.INNKREVING,

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/service/PrivatAvtalePdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/service/PrivatAvtalePdfServiceTest.kt
@@ -39,14 +39,13 @@ class PrivatAvtalePdfServiceTest {
             bidragspliktig = PrivatAvtaleBidragspliktig("Pliktig", "Etternavnesen", "33333333333"),
             barn = listOf(PrivatAvtaleBarn("Barn", "Etternavnesen", "11111111111", 1000.0)),
             fraDato = "01.01.2023",
-            nyAvtale = true,
-            oppgjorsform = Oppgjørsform.INNKREVING,
-            tilInnsending = false,
-            språk = Språkkode.NB,
-            vedlegg = Vedlegg(
-                tilknyttetAvtale = TilknyttetAvtaleVedlegg.SENDES_MED_SKJEMA,
-                annenDokumentasjon = AnnenDokumentasjon.INGEN_EKSTRA_DOKUMENTASJON
+            oppgjør = Oppgjør(
+                nyAvtale = true,
+                oppgjørsformØnsket = Oppgjørsform.INNKREVING,
+                oppgjørsformIdag = Oppgjørsform.INNKREVING,
             ),
+            språk = Språkkode.NB,
+            vedlegg = Vedleggskrav.INGEN_EKSTRA_DOKUMENTASJON,
             andreBestemmelser = AndreBestemmelserSkjema(harAndreBestemmelser = false),
             navSkjemaId = NavSkjemaId.AVTALE_OM_BARNEBIDRAG_UNDER_18
         )
@@ -74,14 +73,13 @@ class PrivatAvtalePdfServiceTest {
             bidragspliktig = PrivatAvtaleBidragspliktig("Pliktig", "Etternavnesen", "33333333333"),
             barn = listOf(PrivatAvtaleBarn("Barn", "Etternavnesen", "11111111111", 1000.0)),
             fraDato = "01.01.2023",
-            nyAvtale = true,
-            oppgjorsform = Oppgjørsform.INNKREVING,
-            tilInnsending = false,
-            språk = Språkkode.NB,
-            vedlegg = Vedlegg(
-                tilknyttetAvtale = TilknyttetAvtaleVedlegg.SENDES_MED_SKJEMA,
-                annenDokumentasjon = AnnenDokumentasjon.INGEN_EKSTRA_DOKUMENTASJON
+            oppgjør = Oppgjør(
+                nyAvtale = true,
+                oppgjørsformØnsket = Oppgjørsform.INNKREVING,
+                oppgjørsformIdag = Oppgjørsform.INNKREVING,
             ),
+            språk = Språkkode.NB,
+            vedlegg = Vedleggskrav.INGEN_EKSTRA_DOKUMENTASJON,
             andreBestemmelser = AndreBestemmelserSkjema(harAndreBestemmelser = false),
             navSkjemaId = NavSkjemaId.AVTALE_OM_BARNEBIDRAG_UNDER_18
         )


### PR DESCRIPTION
### Description

This pull request includes the following changes:

- Updated `PrivatAvtalePdfDto` with a new field `fraDato` for better data representation.
- Added new functionality to format dates into Norwegian format via `medNorskeDatoer()`.
- Replaced `TilknyttetAvtaleVedlegg` and `AnnenDokumentasjon` with a new enum `Vedleggskrav` in DTOs and related configurations.
- Introduced a new `Oppgjør` structure with validation logic.
- Updated field names for clarity, such as splitting `fulltNavn` into `fornavn` and `etternavn` and standardizing `fodselsnummer` to `ident`.
- Enhanced API error handling by including HTTP 400 descriptions and introducing a standardized `GlobalExceptionHandler`.
- Updated and extended related tests and documentation.
