### PR TITLE
Refactor `PrivatAvtalePdf` and enhance date handling

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,6 +94,7 @@ dependencies {
     testImplementation("no.nav.security:token-validation-spring-test:$tokenSupportVersion")
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
+
 }
 
 java {

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdf.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdf.kt
@@ -13,6 +13,7 @@ import no.nav.bidrag.bidragskalkulator.validering.ValidAndreBestemmelser
 import no.nav.bidrag.bidragskalkulator.validering.ValidOppgjør
 import no.nav.bidrag.domene.ident.Personident
 import java.math.BigDecimal
+import java.time.LocalDate
 import java.time.YearMonth
 
 private const val FEILMELDING_FORNAVN = "Fornavn må være utfylt"
@@ -100,7 +101,8 @@ data class PrivatAvtaleBarn(
     val sumBidrag: BigDecimal,  // Beløp in NOK
 
     @param:Schema(description = "Gjelder fra og med dato (YYYY-MM-DD)", required = true, example = "2022-01-01")
-    val fraDato: String,
+    @param:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    val fraDato: LocalDate,
 ) : PrivatAvtalePerson
 
 @ValidAndreBestemmelser

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdf.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdf.kt
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.Size
 import no.nav.bidrag.bidragskalkulator.dto.førstesidegenerator.NavSkjemaId
 import no.nav.bidrag.bidragskalkulator.dto.førstesidegenerator.Språkkode
 import no.nav.bidrag.bidragskalkulator.utils.tilNorskDatoFormat
+import no.nav.bidrag.bidragskalkulator.validering.GyldigPeriode
 import no.nav.bidrag.bidragskalkulator.validering.ValidAndreBestemmelser
 import no.nav.bidrag.bidragskalkulator.validering.ValidOppgjør
 import no.nav.bidrag.domene.ident.Personident
@@ -135,6 +136,7 @@ data class Oppgjør(
     val oppgjørsformIdag: Oppgjørsform? = null
 )
 
+@GyldigPeriode
 @Schema(description = "Informasjon om bidrag som skal betales i en privat avtale for barn over 18 år")
 data class Bidrag(
     @param:Schema(description = "Bidragsbeløp per måned i NOK", required = true, example = "1000")

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdf.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdf.kt
@@ -100,8 +100,8 @@ data class PrivatAvtaleBarn(
     @param:Schema(description = "Barnets fødselsnummer eller d-nummer (11 siffer)", required = true, example = "12345678901")
     val sumBidrag: BigDecimal,  // Beløp in NOK
 
-    @param:Schema(description = "Gjelder fra og med dato (YYYY-MM-DD)", required = true, example = "2022-01-01")
-    @param:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    @param:Schema(description = "Gjelder fra og med dato (dd.MM.yyyy)", required = true, example = "01.01.2025")
+    @param:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd.MM.yyyy")
     val fraDato: LocalDate,
 ) : PrivatAvtalePerson
 

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdf.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdf.kt
@@ -1,5 +1,6 @@
 package no.nav.bidrag.bidragskalkulator.dto
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
@@ -140,9 +141,11 @@ data class Bidrag(
     val bidragPerMåned: BigDecimal,
 
     @param:Schema(description = "Bidraget skal betales fra og med", required = true, example = "2025-01")
+    @param:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM")
     val fraDato: YearMonth,
 
     @param:Schema(description = "Bidraget skal betales til og med", required = true, example = "2025-02")
+    @param:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM")
     val tilDato: YearMonth
 )
 

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdf.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdf.kt
@@ -1,16 +1,13 @@
 package no.nav.bidrag.bidragskalkulator.dto
 
 import com.fasterxml.jackson.annotation.JsonFormat
-import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
-import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import no.nav.bidrag.bidragskalkulator.dto.førstesidegenerator.NavSkjemaId
 import no.nav.bidrag.bidragskalkulator.dto.førstesidegenerator.Språkkode
-import no.nav.bidrag.bidragskalkulator.utils.tilNorskDatoFormat
 import no.nav.bidrag.bidragskalkulator.validering.GyldigPeriode
 import no.nav.bidrag.bidragskalkulator.validering.ValidAndreBestemmelser
 import no.nav.bidrag.bidragskalkulator.validering.ValidOppgjør
@@ -183,13 +180,7 @@ data class PrivatAvtaleBarnUnder18RequestDto(
     @field:Valid
     @param:Schema(description = "Eventuelle andre bestemmelser som er inkludert i avtalen", required = true)
     override val andreBestemmelser: AndreBestemmelserSkjema
-): PrivatAvtalePdf  {
-    @JsonIgnore
-    @Schema(hidden = true)
-    fun medNorskeDatoer(): PrivatAvtaleBarnUnder18RequestDto = this.copy(
-        barn = this.barn.map { it.copy(fraDato = it.fraDato.tilNorskDatoFormat()) },
-    )
-}
+): PrivatAvtalePdf
 
 @Schema(description = "Informasjon for generering av en privat avtale PDF for barn over 18 år")
 data class PrivatAvtaleBarnOver18RequestDto (

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdf.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/PrivatAvtalePdf.kt
@@ -14,6 +14,7 @@ import no.nav.bidrag.bidragskalkulator.validering.ValidAndreBestemmelser
 import no.nav.bidrag.bidragskalkulator.validering.ValidOppgjør
 import no.nav.bidrag.domene.ident.Personident
 import java.math.BigDecimal
+import java.time.YearMonth
 
 private const val FEILMELDING_FORNAVN = "Fornavn må være utfylt"
 private const val FEILMELDING_ETTERNAVN = "Etternavn må være utfylt"
@@ -135,15 +136,14 @@ data class Oppgjør(
 
 @Schema(description = "Informasjon om bidrag som skal betales i en privat avtale for barn over 18 år")
 data class Bidrag(
-    @param:Min(value = 1, message = "Beløpet må være større enn 0")
     @param:Schema(description = "Bidragsbeløp per måned i NOK", required = true, example = "1000")
     val bidragPerMåned: BigDecimal,
 
-    @param:Schema(description = "Bidraget skal betales fra og med", required = true, example = "01-2025")
-    val fraDato: String,
+    @param:Schema(description = "Bidraget skal betales fra og med", required = true, example = "2025-01")
+    val fraDato: YearMonth,
 
-    @param:Schema(description = "Bidraget skal betales til og med", required = true, example = "12-2025")
-    val tilDato: String
+    @param:Schema(description = "Bidraget skal betales til og med", required = true, example = "2025-02")
+    val tilDato: YearMonth
 )
 
 @Schema(description = "Informasjon for generering av en privat avtale PDF for barn under 18 år")

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/exception/GlobalExceptionHandler.kt
@@ -13,6 +13,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import java.time.YearMonth
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
@@ -45,7 +46,8 @@ class GlobalExceptionHandler {
     }
 
     /**
-     * Gjelder typisk feil enum-verdi i JSON body (Jackson deserialisering).
+     * Kastes når Spring ikke klarer å deserialisere JSON-body til objektet.
+     * f.eks. ugyldig verdi i JSON for et felt (f.eks. "fraDato": "2025/08" når DTO har YearMonth) eller ugyldig enum-verdi i body
      */
     @ExceptionHandler(HttpMessageNotReadableException::class)
     fun handleHttpMessageNotReadable(e: HttpMessageNotReadableException): ProblemDetail {
@@ -59,21 +61,35 @@ class GlobalExceptionHandler {
                 val msg = "Ugyldig verdi '$provided' for felt '$field'. Tillatte verdier: $allowed."
                 return problem(HttpStatus.BAD_REQUEST, msg, msg)
             }
+
+            if (target == YearMonth::class.java) {
+                val field = cause.path.lastOrNull()?.let(JsonMappingException.Reference::getFieldName) ?: "ukjent felt"
+                val provided = cause.value?.toString() ?: "null"
+                val msg = "Ugyldig datoformat for felt '$field'. Forventet format er 'yyyy-MM' (f.eks. 2025-08). Mottok: '$provided'."
+                return problem(HttpStatus.BAD_REQUEST, msg, msg)
+            }
         }
         return problem(HttpStatus.BAD_REQUEST, "Ugyldig request body (kunne ikke tolkes).")
     }
 
     /**
-     * Gjelder typisk feil enum-verdi i query/path-parametre.
+     * Kastes når en query parameter eller path variable ikke kan konverteres til riktig type.
+     * f.eks. URL: /api/v1/bidrag?fraDato=2025/08 når metodesignaturen har fraDato: YearMonth.
      */
     @ExceptionHandler(MethodArgumentTypeMismatchException::class)
     fun handleMethodArgumentTypeMismatch(e: MethodArgumentTypeMismatchException): ProblemDetail {
         val required = e.requiredType
-        val msg = if (required != null && required.isEnum) {
-            val allowed = required.enumConstants.joinToString(", ") { (it as Enum<*>).name }
-            "Ugyldig verdi '${e.value}' for parameter '${e.name}'. Tillatte verdier: $allowed."
-        } else {
-            "Ugyldig verdi for parameter '${e.name}'. Forventet type: ${required?.simpleName ?: "ukjent"}."
+        val msg = when {
+            required == YearMonth::class.java -> {
+                "Ugyldig verdi '${e.value}' for parameter '${e.name}'. Forventet format for YearMonth er 'yyyy-MM' (f.eks. 2025-08)."
+            }
+            required != null && required.isEnum -> {
+                val allowed = required.enumConstants.joinToString(", ") { (it as Enum<*>).name }
+                "Ugyldig verdi '${e.value}' for parameter '${e.name}'. Tillatte verdier: $allowed."
+            }
+            else -> {
+                "Ugyldig verdi for parameter '${e.name}'. Forventet type: ${required?.simpleName ?: "ukjent"}."
+            }
         }
         return problem(HttpStatus.BAD_REQUEST, msg, msg)
     }

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/exception/GlobalExceptionHandler.kt
@@ -73,7 +73,7 @@ class GlobalExceptionHandler {
             if (target == LocalDate::class.java) {
                 val field = cause.path.lastOrNull()?.let(JsonMappingException.Reference::getFieldName) ?: "ukjent felt"
                 val provided = cause.value?.toString() ?: "null"
-                val msg = "Ugyldig datoformat for felt '$field'. Forventet format er 'YYYY-MM-DD' (f.eks. 2025-08-01). Mottok: '$provided'."
+                val msg = "Ugyldig datoformat for felt '$field'. Forventet format er 'dd.MM.yyyyD' (f.eks. 08.01.2025). Mottok: '$provided'."
                 return problem(HttpStatus.BAD_REQUEST, msg, msg)
             }
         }
@@ -92,7 +92,7 @@ class GlobalExceptionHandler {
                 "Ugyldig verdi '${e.value}' for parameter '${e.name}'. Forventet format for YearMonth er 'yyyy-MM' (f.eks. 2025-08)."
             }
             required == LocalDate::class.java -> {
-                "Ugyldig verdi '${e.value}' for parameter '${e.name}'. Forventet format for YearMonth er 'YYYY-MM-DD' (f.eks. 2025-08-01)."
+                "Ugyldig verdi '${e.value}' for parameter '${e.name}'. Forventet format for YearMonth er 'dd.MM.yyyy' (f.eks. 08.01.2025)."
             }
             required != null && required.isEnum -> {
                 val allowed = required.enumConstants.joinToString(", ") { (it as Enum<*>).name }

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/exception/GlobalExceptionHandler.kt
@@ -13,6 +13,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import java.time.LocalDate
 import java.time.YearMonth
 
 @RestControllerAdvice
@@ -68,6 +69,13 @@ class GlobalExceptionHandler {
                 val msg = "Ugyldig datoformat for felt '$field'. Forventet format er 'yyyy-MM' (f.eks. 2025-08). Mottok: '$provided'."
                 return problem(HttpStatus.BAD_REQUEST, msg, msg)
             }
+
+            if (target == LocalDate::class.java) {
+                val field = cause.path.lastOrNull()?.let(JsonMappingException.Reference::getFieldName) ?: "ukjent felt"
+                val provided = cause.value?.toString() ?: "null"
+                val msg = "Ugyldig datoformat for felt '$field'. Forventet format er 'YYYY-MM-DD' (f.eks. 2025-08-01). Mottok: '$provided'."
+                return problem(HttpStatus.BAD_REQUEST, msg, msg)
+            }
         }
         return problem(HttpStatus.BAD_REQUEST, "Ugyldig request body (kunne ikke tolkes).")
     }
@@ -82,6 +90,9 @@ class GlobalExceptionHandler {
         val msg = when {
             required == YearMonth::class.java -> {
                 "Ugyldig verdi '${e.value}' for parameter '${e.name}'. Forventet format for YearMonth er 'yyyy-MM' (f.eks. 2025-08)."
+            }
+            required == LocalDate::class.java -> {
+                "Ugyldig verdi '${e.value}' for parameter '${e.name}'. Forventet format for YearMonth er 'YYYY-MM-DD' (f.eks. 2025-08-01)."
             }
             required != null && required.isEnum -> {
                 val allowed = required.enumConstants.joinToString(", ") { (it as Enum<*>).name }

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagBuilder.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagBuilder.kt
@@ -3,8 +3,6 @@ package no.nav.bidrag.bidragskalkulator.mapper
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import no.nav.bidrag.beregn.barnebidrag.bo.NettoTilsynsutgiftPeriode
-import no.nav.bidrag.beregn.barnebidrag.bo.NettoTilsynsutgiftPeriodeGrunnlag
 import no.nav.bidrag.bidragskalkulator.dto.BidragsType
 import no.nav.bidrag.bidragskalkulator.mapper.BeregningsgrunnlagMapper.Referanser
 import no.nav.bidrag.bidragskalkulator.utils.kalkulerAlder

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/PrivatAvtaleMapper.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/PrivatAvtaleMapper.kt
@@ -10,7 +10,6 @@ import no.nav.bidrag.bidragskalkulator.dto.førstesidegenerator.FørstesideBruke
 import no.nav.bidrag.bidragskalkulator.dto.førstesidegenerator.GenererFørstesideRequestDto
 import no.nav.bidrag.bidragskalkulator.dto.førstesidegenerator.Foerstesidetype
 import no.nav.bidrag.bidragskalkulator.dto.førstesidegenerator.NavSkjemaId
-import no.nav.bidrag.bidragskalkulator.utils.tilNorskDatoFormat
 
 fun PrivatAvtalePdf.navnSkjemaIdFor(): NavSkjemaId = when (this) {
     is PrivatAvtaleBarnUnder18RequestDto -> NavSkjemaId.AVTALE_OM_BARNEBIDRAG_UNDER_18
@@ -50,7 +49,7 @@ fun PrivatAvtaleBarnUnder18RequestDto.normalisert(): PrivatAvtaleBarnUnder18Requ
         barn = barn
             .asSequence()
             .sortedBy { it.fraDato }
-            .map { it.copy(fraDato = it.fraDato.tilNorskDatoFormat()) }
+            .map { it.copy(fraDato = it.fraDato) }
             .toList()
     )
 

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/PrivatAvtaleMapper.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/PrivatAvtaleMapper.kt
@@ -10,6 +10,7 @@ import no.nav.bidrag.bidragskalkulator.dto.førstesidegenerator.FørstesideBruke
 import no.nav.bidrag.bidragskalkulator.dto.førstesidegenerator.GenererFørstesideRequestDto
 import no.nav.bidrag.bidragskalkulator.dto.førstesidegenerator.Foerstesidetype
 import no.nav.bidrag.bidragskalkulator.dto.førstesidegenerator.NavSkjemaId
+import no.nav.bidrag.bidragskalkulator.utils.tilNorskDatoFormat
 
 fun PrivatAvtalePdf.navnSkjemaIdFor(): NavSkjemaId = when (this) {
     is PrivatAvtaleBarnUnder18RequestDto -> NavSkjemaId.AVTALE_OM_BARNEBIDRAG_UNDER_18
@@ -43,6 +44,22 @@ fun PrivatAvtalePdf.tilGenererFørstesideRequestDto(innsenderIdent: String,
         foerstesidetype = Foerstesidetype.SKJEMA
     )
 }
+
+fun PrivatAvtaleBarnUnder18RequestDto.normalisert(): PrivatAvtaleBarnUnder18RequestDto =
+    copy(
+        barn = barn
+            .asSequence()
+            .sortedBy { it.fraDato }
+            .map { it.copy(fraDato = it.fraDato.tilNorskDatoFormat()) }
+            .toList()
+    )
+
+
+fun PrivatAvtaleBarnOver18RequestDto.normalisert(): PrivatAvtaleBarnOver18RequestDto =
+    copy(
+        bidrag = bidrag.sortedBy { it.fraDato }
+    )
+
 
 /**
  * Sjekker om førsteside skal genereres basert på oppgjørsform og avtaletype.

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/PrivatAvtalePdfService.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/PrivatAvtalePdfService.kt
@@ -19,7 +19,7 @@ import kotlin.time.measureTimedValue
 @Service
 class PrivatAvtalePdfService(
     val bidragDokumentConsumer: BidragDokumentProduksjonConsumer,
-    val foerstesideConsumer: FørstesidegeneratorConsumer,
+    val førstesideConsumer: FørstesidegeneratorConsumer,
     val pdfProcessor: PdfProsessor
 ) {
 
@@ -47,7 +47,7 @@ class PrivatAvtalePdfService(
 
         if(normalisertDto.oppgjør.skalFørstesideGenereres()) {
             val request = normalisertDto.tilGenererFørstesideRequestDto(innsenderIdent)
-            val førsteside = measureTimedValue { foerstesideConsumer.genererFørsteside(request).foersteside }
+            val førsteside = measureTimedValue { førstesideConsumer.genererFørsteside(request).foersteside }
                 .also { logger
                     .info("Privat avtale for barn $label: Førsteside generert på ${it.duration.inWholeMilliseconds} ms") }
                 .value

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/utils/DateUtils.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/utils/DateUtils.kt
@@ -4,7 +4,6 @@ package no.nav.bidrag.bidragskalkulator.utils
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
 import java.time.Period
-import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 
 private val secureLogger = LoggerFactory.getLogger("secureLogger")
@@ -15,23 +14,5 @@ fun kalkulerAlder(fødselsdato: LocalDate): Int {
     } catch (e: DateTimeParseException) {
         secureLogger.warn("Feil ved kalkulering av alder for fødselsdato $fødselsdato", e)
         0
-    }
-}
-
-fun String.tilNorskDatoFormat(): String {
-    return try {
-        // Forutsatt at inndataene er i formatet åååå-MM-dd eller dd.MM.åååå
-        val date = when {
-            this.contains("-") -> LocalDate.parse(this)
-            this.contains(".") -> LocalDate.parse(this, DateTimeFormatter.ofPattern("dd.MM.yyyy"))
-            else -> throw IllegalArgumentException("Ugyldig datoformat. Dato må være på format 'dd.MM.yyyy' eller 'yyyy-MM-dd'. Mottok: '$this'")
-        }
-
-        date.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))
-    } catch (e: DateTimeParseException) {
-        throw IllegalArgumentException(
-            "Kunne ikke konvertere '$this' til gyldig dato. Dato må være på format 'dd.MM.yyyy' eller 'yyyy-MM-dd",
-            e
-        )
     }
 }

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/validering/GyldigPeriodeValidator.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/validering/GyldigPeriodeValidator.kt
@@ -1,0 +1,23 @@
+package no.nav.bidrag.bidragskalkulator.validering
+
+import jakarta.validation.Constraint
+import jakarta.validation.ConstraintValidator
+import jakarta.validation.ConstraintValidatorContext
+import jakarta.validation.Payload
+import no.nav.bidrag.bidragskalkulator.dto.Bidrag
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@Constraint(validatedBy = [GyldigPeriodeValidator::class])
+annotation class GyldigPeriode(
+    val message: String = "tilDato kan ikke være før fraDato",
+    val groups: Array<KClass<*>> = [],
+    val payload: Array<KClass<out Payload>> = []
+)
+
+class GyldigPeriodeValidator : ConstraintValidator<GyldigPeriode, Bidrag> {
+    override fun isValid(bidrag: Bidrag, context: ConstraintValidatorContext): Boolean {
+        return bidrag.tilDato >= bidrag.fraDato
+    }
+}

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/AbstractControllerTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/AbstractControllerTest.kt
@@ -1,7 +1,10 @@
 package no.nav.bidrag.bidragskalkulator.controller
 
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import no.nav.security.mock.oauth2.MockOAuth2Server
-import no.nav.security.mock.oauth2.http.objectMapper
 import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -33,6 +36,11 @@ abstract class AbstractControllerTest {
 
     @Autowired
     protected lateinit var ugyldigOAuth2Token: String
+
+    protected val objectMapper = jacksonObjectMapper()
+        .registerKotlinModule()
+        .registerModule(JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 
     protected fun postRequest(url: String, body: Any, token: String? = null): ResultActions {
         return mockMvc.perform(buildJsonRequest(post(url), body, token))

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/PrivatAvtaleControllerTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/PrivatAvtaleControllerTest.kt
@@ -4,9 +4,11 @@ import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import io.mockk.verify
 import no.nav.bidrag.bidragskalkulator.dto.AndreBestemmelserSkjema
+import no.nav.bidrag.bidragskalkulator.dto.Bidrag
 import no.nav.bidrag.bidragskalkulator.dto.Oppgjør
 import no.nav.bidrag.bidragskalkulator.dto.Oppgjørsform
 import no.nav.bidrag.bidragskalkulator.dto.PrivatAvtaleBarn
+import no.nav.bidrag.bidragskalkulator.dto.PrivatAvtaleBarnOver18RequestDto
 import no.nav.bidrag.bidragskalkulator.dto.PrivatAvtalePart
 import no.nav.bidrag.bidragskalkulator.dto.PrivatAvtaleBarnUnder18RequestDto
 import no.nav.bidrag.bidragskalkulator.dto.Vedleggskrav
@@ -18,11 +20,13 @@ import no.nav.bidrag.bidragskalkulator.utils.InnloggetBrukerUtils
 import no.nav.bidrag.bidragskalkulator.utils.JsonUtils
 import no.nav.bidrag.domene.ident.Personident
 import no.nav.bidrag.transport.person.MotpartBarnRelasjonDto
+import org.junit.jupiter.api.Nested
 import org.springframework.http.MediaType.APPLICATION_PDF
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 import java.io.ByteArrayOutputStream
 import java.math.BigDecimal
 import java.time.LocalDate
+import java.time.YearMonth
 import kotlin.test.Test
 
 class PrivatAvtaleControllerTest: AbstractControllerTest() {
@@ -36,104 +40,209 @@ class PrivatAvtaleControllerTest: AbstractControllerTest() {
     private val mockResponsPersonMedEnBarnRelasjon: MotpartBarnRelasjonDto =
         JsonUtils.readJsonFile("/person/person_med_barn_et_motpart.json")
 
-    @Test
-    fun `skal returnere informasjon for privat avtale`() {
-        val personIdent = "03848797048"
-        val forventetDto = mockResponsPersonMedEnBarnRelasjon.person.tilPrivatAvtaleInformasjonDto()
+    // Minimal PDF-like bytes: "%PDF-1.4\n%%EOF"
+    private val pdfMock = byteArrayOf(
+        0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x34, 0x0A, 0x25, 0x25, 0x45, 0x4F, 0x46
+    )
 
-        every { innloggetBrukerUtils.hentPåloggetPersonIdent() } returns personIdent
-        every { privatAvtaleService.hentInformasjonForPrivatAvtale(personIdent) } returns forventetDto
+    @Nested
+    inner class BarnUnder18 {
+        @Test
+        fun `skal returnere informasjon for privat avtale`() {
+            val personIdent = "03848797048"
+            val forventetDto = mockResponsPersonMedEnBarnRelasjon.person.tilPrivatAvtaleInformasjonDto()
 
-        getRequest("/api/v1/privat-avtale/informasjon", gyldigOAuth2Token)
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.fornavn").value(forventetDto.fornavn))
-            .andExpect(jsonPath("$.etternavn").value(forventetDto.etternavn))
-            .andExpect(jsonPath("$.ident").value(forventetDto.ident.verdi))
-    }
+            every { innloggetBrukerUtils.hentPåloggetPersonIdent() } returns personIdent
+            every { privatAvtaleService.hentInformasjonForPrivatAvtale(personIdent) } returns forventetDto
 
-    @Test
-    fun `skal gi feil hvis personIdent ikke kan hentes`() {
-        every { innloggetBrukerUtils.hentPåloggetPersonIdent() } returns null
+            getRequest("/api/v1/privat-avtale/informasjon", gyldigOAuth2Token)
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.fornavn").value(forventetDto.fornavn))
+                .andExpect(jsonPath("$.etternavn").value(forventetDto.etternavn))
+                .andExpect(jsonPath("$.ident").value(forventetDto.ident.verdi))
+        }
 
-        getRequest("/api/v1/privat-avtale/informasjon", ugyldigOAuth2Token)
-            .andExpect(status().isUnauthorized)
-            .andExpect(jsonPath("$.detail").value("Ugyldig eller manglende token"))
-    }
+        @Test
+        fun `skal gi feil hvis personIdent ikke kan hentes`() {
+            every { innloggetBrukerUtils.hentPåloggetPersonIdent() } returns null
 
-    @Test
-    fun `skal generere privat avtale PDF`() {
-        val personIdent = "12345678910"
-        val dto = lagGyldigPrivatAvtaleBarnUnder18RequestDto()
+            getRequest("/api/v1/privat-avtale/informasjon", ugyldigOAuth2Token)
+                .andExpect(status().isUnauthorized)
+                .andExpect(jsonPath("$.detail").value("Ugyldig eller manglende token"))
+        }
 
-        every { innloggetBrukerUtils.hentPåloggetPersonIdent() } returns personIdent
+        @Test
+        fun `skal generere privat avtale PDF`() {
+            val personIdent = "12345678910"
+            val dto = lagGyldigPrivatAvtaleBarnUnder18RequestDto()
 
-        every { privatAvtalePdfService.genererPrivatAvtalePdf(personIdent, dto) } returns
-                ByteArrayOutputStream().apply {
-                    // Minimal PDF-like bytes: "%PDF-1.4\n%%EOF"
-                    write(byteArrayOf(0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x34, 0x0A, 0x25, 0x25, 0x45, 0x4F, 0x46))
-                }
+            every { innloggetBrukerUtils.hentPåloggetPersonIdent() } returns personIdent
 
-        postRequest(
-            "/api/v1/privat-avtale/under-18",
-            dto,
-            gyldigOAuth2Token
-        )
-            .andExpect(status().isOk)
-            .andExpect(content().contentType(APPLICATION_PDF))
-            .andExpect(header().string("Content-Disposition", "inline; filename=\"privatavtale.pdf\""))
-    }
+            every { privatAvtalePdfService.genererPrivatAvtalePdf(personIdent, dto) } returns
+                    ByteArrayOutputStream().apply { write(pdfMock) }
 
-    @Test
-    fun `skal gi feil hvis harAndreBestemmelser er true men beskrivelse mangler`() {
-        val dto = lagGyldigPrivatAvtaleBarnUnder18RequestDto().copy(
-            andreBestemmelser = AndreBestemmelserSkjema(harAndreBestemmelser = true, beskrivelse = null)
-        )
-        val personIdent = "12345678910"
-        every { innloggetBrukerUtils.hentPåloggetPersonIdent() } returns personIdent
-        every { privatAvtalePdfService.genererPrivatAvtalePdf(any(), any()) } returns ByteArrayOutputStream()
-
-        postRequest("/api/v1/privat-avtale/under-18", dto, gyldigOAuth2Token)
-            .andExpect(status().isBadRequest)
-            .andExpect(jsonPath("\$.detail")
-                .value("andreBestemmelser.beskrivelse: beskrivelse må settes når harAndreBestemmelser=true"))
-
-        // Tjenesten skal ikke kalles når validering feiler
-        verify(exactly = 0) { privatAvtalePdfService.genererPrivatAvtalePdf(any(), any()) }
-    }
-
-    @Test
-    fun `skal gi feil hvis nyAvtale er false og oppgjørsformIdag er null`() {
-        val dto = lagGyldigPrivatAvtaleBarnUnder18RequestDto().copy(
-            oppgjør = Oppgjør(
-                nyAvtale = false,
-                oppgjørsformØnsket = Oppgjørsform.INNKREVING,
-                oppgjørsformIdag = null // trigger @ValidOppgjør
+            postRequest(
+                "/api/v1/privat-avtale/under-18",
+                dto,
+                gyldigOAuth2Token
             )
-        )
-        val personIdent = "12345678910"
-        every { innloggetBrukerUtils.hentPåloggetPersonIdent() } returns personIdent
-        every { privatAvtalePdfService.genererPrivatAvtalePdf(any(), any()) } returns ByteArrayOutputStream()
+                .andExpect(status().isOk)
+                .andExpect(content().contentType(APPLICATION_PDF))
+                .andExpect(header()
+                    .string("Content-Disposition", "inline; filename=\"privatavtale.pdf\""))
+        }
 
-        postRequest("/api/v1/privat-avtale/under-18", dto, gyldigOAuth2Token)
-            .andExpect(status().isBadRequest)
-            .andExpect(jsonPath("\$.detail")
-                .value("oppgjør.oppgjørsformIdag: oppgjørsformIdag må settes når nyAvtale=false"))
+        @Test
+        fun `skal gi feil hvis harAndreBestemmelser er true men beskrivelse mangler`() {
+            val dto = lagGyldigPrivatAvtaleBarnUnder18RequestDto().copy(
+                andreBestemmelser = AndreBestemmelserSkjema(harAndreBestemmelser = true, beskrivelse = null)
+            )
+            val personIdent = "12345678910"
+            every { innloggetBrukerUtils.hentPåloggetPersonIdent() } returns personIdent
+            every { privatAvtalePdfService.genererPrivatAvtalePdf(any(), any()) } returns
+                    ByteArrayOutputStream()
 
-        verify(exactly = 0) { privatAvtalePdfService.genererPrivatAvtalePdf(any(), any()) }
+            postRequest("/api/v1/privat-avtale/under-18", dto, gyldigOAuth2Token)
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("\$.detail")
+                    .value(
+                        "andreBestemmelser.beskrivelse: beskrivelse må settes når harAndreBestemmelser=true"
+                    )
+                )
+
+            // Tjenesten skal ikke kalles når validering feiler
+            verify(exactly = 0) { privatAvtalePdfService.genererPrivatAvtalePdf(any(), any()) }
+        }
+
+        @Test
+        fun `skal gi feil hvis nyAvtale er false og oppgjørsformIdag er null`() {
+            val dto = lagGyldigPrivatAvtaleBarnUnder18RequestDto().copy(
+                oppgjør = Oppgjør(
+                    nyAvtale = false,
+                    oppgjørsformØnsket = Oppgjørsform.INNKREVING,
+                    oppgjørsformIdag = null // trigger @ValidOppgjør
+                )
+            )
+            val personIdent = "12345678910"
+            every { innloggetBrukerUtils.hentPåloggetPersonIdent() } returns personIdent
+            every { privatAvtalePdfService.genererPrivatAvtalePdf(any(), any()) } returns ByteArrayOutputStream()
+
+            postRequest("/api/v1/privat-avtale/under-18", dto, gyldigOAuth2Token)
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("\$.detail")
+                    .value("oppgjør.oppgjørsformIdag: oppgjørsformIdag må settes når nyAvtale=false"))
+
+            verify(exactly = 0) { privatAvtalePdfService.genererPrivatAvtalePdf(any(), any()) }
+        }
+
+        private fun lagGyldigPrivatAvtaleBarnUnder18RequestDto(): PrivatAvtaleBarnUnder18RequestDto {
+            return PrivatAvtaleBarnUnder18RequestDto(
+                språk = Språkkode.NB,
+                bidragsmottaker = PrivatAvtalePart(
+                    "Ola",
+                    "Nordmann",
+                    Personident("12345678901")
+                ),
+                bidragspliktig = PrivatAvtalePart(
+                    "Kari",
+                    "Nordmann",
+                    Personident("10987654321")
+                ),
+                barn = listOf(PrivatAvtaleBarn(
+                    "Barn",
+                    "Nordmann",
+                    Personident("01010112345"),
+                    BigDecimal("1000"),
+                    fraDato = LocalDate.of(2025, 1, 15)
+                )),
+                oppgjør = Oppgjør(nyAvtale = true, oppgjørsformØnsket = Oppgjørsform.INNKREVING),
+                vedlegg = Vedleggskrav.INGEN_EKSTRA_DOKUMENTASJON,
+                andreBestemmelser = AndreBestemmelserSkjema(false, null)
+            )
+        }
     }
 
-    private fun lagGyldigPrivatAvtaleBarnUnder18RequestDto(): PrivatAvtaleBarnUnder18RequestDto {
-        return PrivatAvtaleBarnUnder18RequestDto(
-            språk = Språkkode.NB,
-            bidragsmottaker = PrivatAvtalePart("Ola", "Nordmann", Personident("12345678901")),
-            bidragspliktig = PrivatAvtalePart("Kari", "Nordmann", Personident("10987654321")),
-            barn = listOf(PrivatAvtaleBarn(
-                "Barn", "Nordmann", Personident("01010112345"), BigDecimal("1000"),
-                fraDato = LocalDate.of(2025, 1, 15)
-            )),
-            oppgjør = Oppgjør(nyAvtale = true, oppgjørsformØnsket = Oppgjørsform.INNKREVING),
-            vedlegg = Vedleggskrav.INGEN_EKSTRA_DOKUMENTASJON,
-            andreBestemmelser = AndreBestemmelserSkjema(false, null)
-        )
+    @Nested
+    inner class BarnOver18 {
+        @Test
+        fun `skal generere privat avtale PDF for barn over 18`() {
+            val personIdent = "12345678910"
+            val dto = lagGyldigPrivatAvtaleBarnOver18RequestDto()
+
+            every { innloggetBrukerUtils.hentPåloggetPersonIdent() } returns personIdent
+            every { privatAvtalePdfService.genererPrivatAvtalePdf(personIdent, dto) } returns
+                    ByteArrayOutputStream().apply { write(pdfMock) }
+
+            postRequest(
+                "/api/v1/privat-avtale/over-18",
+                dto,
+                gyldigOAuth2Token
+            )
+                .andExpect(status().isOk)
+                .andExpect(content().contentType(APPLICATION_PDF))
+                .andExpect(
+                    header().string(
+                        "Content-Disposition", "inline; filename=\"privatavtale.pdf\""
+                    )
+                )
+
+            verify(exactly = 1) { privatAvtalePdfService.genererPrivatAvtalePdf(personIdent, dto) }
+        }
+
+        @Test
+        fun `skal gi feil for barn over 18 hvis tilDato er før fraDato`() {
+            val personIdent = "12345678910"
+
+            // Ugyldig: tilDato < fraDato
+            val ugyldigDto = lagGyldigPrivatAvtaleBarnOver18RequestDto().copy(
+                bidrag = listOf(
+                    Bidrag(
+                        bidragPerMåned = BigDecimal("1200"),
+                        fraDato = YearMonth.of(2025, 5),
+                        tilDato = YearMonth.of(2025, 4) // trigger @GyldigPeriode
+                    )
+                )
+            )
+
+            every { innloggetBrukerUtils.hentPåloggetPersonIdent() } returns personIdent
+            every { privatAvtalePdfService.genererPrivatAvtalePdf(any(), any()) } returns
+                    ByteArrayOutputStream()
+
+            postRequest("/api/v1/privat-avtale/over-18", ugyldigDto, gyldigOAuth2Token)
+                .andExpect(status().isBadRequest)
+                .andExpect(jsonPath("\$.detail")
+                    .value(org.hamcrest.Matchers.containsString(
+                        "tilDato kan ikke være før fraDato"
+                    )))
+
+            verify(exactly = 0) { privatAvtalePdfService.genererPrivatAvtalePdf(any(), any()) }
+        }
+
+        private fun lagGyldigPrivatAvtaleBarnOver18RequestDto(): PrivatAvtaleBarnOver18RequestDto {
+            return PrivatAvtaleBarnOver18RequestDto(
+                språk = Språkkode.NB,
+                bidragsmottaker = PrivatAvtalePart(
+                    "Ola",
+                    "Nordmann",
+                    Personident("12345678901")
+                ),
+                bidragspliktig = PrivatAvtalePart(
+                    "Kari",
+                    "Nordmann",
+                    Personident("10987654321")
+                ),
+                bidrag = listOf(
+                    Bidrag(
+                        bidragPerMåned = BigDecimal("1500"),
+                        fraDato = YearMonth.of(2025, 1),
+                        tilDato = YearMonth.of(2025, 3)
+                    )
+                ),
+                oppgjør = Oppgjør(nyAvtale = true, oppgjørsformØnsket = Oppgjørsform.INNKREVING),
+                vedlegg = Vedleggskrav.INGEN_EKSTRA_DOKUMENTASJON,
+                andreBestemmelser = AndreBestemmelserSkjema(false, null)
+            )
+        }
+
     }
 }

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/PrivatAvtaleControllerTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/PrivatAvtaleControllerTest.kt
@@ -22,6 +22,7 @@ import org.springframework.http.MediaType.APPLICATION_PDF
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 import java.io.ByteArrayOutputStream
 import java.math.BigDecimal
+import java.time.LocalDate
 import kotlin.test.Test
 
 class PrivatAvtaleControllerTest: AbstractControllerTest() {
@@ -67,7 +68,7 @@ class PrivatAvtaleControllerTest: AbstractControllerTest() {
         every { innloggetBrukerUtils.hentPåloggetPersonIdent() } returns personIdent
 
         every { privatAvtalePdfService.genererPrivatAvtalePdf(personIdent, dto) } returns
-                java.io.ByteArrayOutputStream().apply {
+                ByteArrayOutputStream().apply {
                     // Minimal PDF-like bytes: "%PDF-1.4\n%%EOF"
                     write(byteArrayOf(0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x34, 0x0A, 0x25, 0x25, 0x45, 0x4F, 0x46))
                 }
@@ -126,7 +127,10 @@ class PrivatAvtaleControllerTest: AbstractControllerTest() {
             språk = Språkkode.NB,
             bidragsmottaker = PrivatAvtalePart("Ola", "Nordmann", Personident("12345678901")),
             bidragspliktig = PrivatAvtalePart("Kari", "Nordmann", Personident("10987654321")),
-            barn = listOf(PrivatAvtaleBarn("Barn", "Nordmann", Personident("01010112345"), BigDecimal("1000"), fraDato = "2025-01-01")),
+            barn = listOf(PrivatAvtaleBarn(
+                "Barn", "Nordmann", Personident("01010112345"), BigDecimal("1000"),
+                fraDato = LocalDate.of(2025, 1, 15)
+            )),
             oppgjør = Oppgjør(nyAvtale = true, oppgjørsformØnsket = Oppgjørsform.INNKREVING),
             vedlegg = Vedleggskrav.INGEN_EKSTRA_DOKUMENTASJON,
             andreBestemmelser = AndreBestemmelserSkjema(false, null)

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/service/PrivatAvtalePdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/service/PrivatAvtalePdfServiceTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayOutputStream
 import java.math.BigDecimal
+import java.time.LocalDate
 
 class PrivatAvtalePdfServiceTest {
 
@@ -51,7 +52,7 @@ class PrivatAvtalePdfServiceTest {
                 PrivatAvtaleBarn(
                     "Barn", "Etternavnesen", Personident("11111111111"),
                     sumBidrag = BigDecimal("1000"),
-                    fraDato = "2025-01-01"
+                    fraDato = LocalDate.now()
                 )
             ),
             oppgjør = Oppgjør(nyAvtale = nyAvtale, oppgjørsformØnsket = ønsket, oppgjørsformIdag = idag),


### PR DESCRIPTION
- Refactored `PrivatAvtaleControllerTest` by grouping tests into nested classes based on age groups and added support for private agreements for individuals over 18 years old.
- Standardized date formats across tests with `LocalDate` and updated `AbstractControllerTest` with new `objectMapper` configuration.
- Standardized the date format to `dd.MM.yyyy` in `GlobalExceptionHandler` and `PrivatAvtalePdf` for improved readability and consistency.
- Updated `GlobalExceptionHandler` to handle `LocalDate` formatting errors, removed unused methods for date conversion, and standardized `LocalDate` usage in `PrivatAvtalePdf`.
- Refactored `PrivatAvtalePdfService` to use normalization methods for DTOs and removed redundant code in `PrivatAvtalePdf`.
- Sorted contributions by `fraDato` for those over 18 years old and refactored variable names in `PrivatAvtalePdfService` for clarity.
- Added validation annotation for valid periods in `Bidrag` and implemented `GyldigPeriodeValidator`.
- Enhanced `YearMonth` handling in `GlobalExceptionHandler` and added JSON formatting for dates in `PrivatAvtalePdf`.
- Updated `PrivatAvtalePdf` to utilize `YearMonth` for dates and adjusted related descriptions.