### PR TITLE
Fjern secure-logs konfig

### DIFF
--- a/.nais/naiserator.yaml
+++ b/.nais/naiserator.yaml
@@ -38,9 +38,6 @@ spec:
       value: "{{this}}"
     {{/each}}
 
-  secureLogs:
-    enabled: true
-
   prometheus:
     enabled: true
     path: /actuator/prometheus
@@ -53,7 +50,6 @@ spec:
       destinations:
         - id: loki
         - id: elastic
-        - id: secure_logs
 
   accessPolicy:
     inbound:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -38,21 +38,6 @@
     </appender>
 
     <springProfile name="prod,dev">
-        <appender name="secureLog" class="ch.qos.logback.core.rolling.RollingFileAppender">
-            <filter class="no.nav.bidrag.commons.logging.BidragDebugLogFilter"/>
-            <file>/secure-logs/secure.log</file>
-            <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-                <fileNamePattern>/secure-logs/secure.log.%i</fileNamePattern>
-                <minIndex>1</minIndex>
-                <maxIndex>1</maxIndex>
-            </rollingPolicy>
-            <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-                <maxFileSize>50MB</maxFileSize>
-            </triggeringPolicy>
-            <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
-        </appender>
-    </springProfile>
-    <springProfile name="prod,dev">
         <appender name="team-logs" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
             <filter class="no.nav.bidrag.commons.logging.BidragDebugLogFilter"/>
             <destination>team-logs.nais-system:5170</destination>
@@ -75,7 +60,6 @@
             <appender-ref ref="team-logs" />
         </root>
         <logger name="secureLogger" level="INFO" additivity="false" >
-            <appender-ref ref="secureLog" />
             <appender-ref ref="team-logs" />
         </logger>
     </springProfile>


### PR DESCRIPTION
This pull request removes the configuration related to secure-logs. Specifically, it updates `logback-spring.xml` and `naiserator.yaml` by eliminating unused logging and associated settings.