### PR TITLE
Feature/sjablon for maks barn årsinntekt

### DIFF
--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/BidragskalkulatorGrunnlagDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/BidragskalkulatorGrunnlagDto.kt
@@ -9,5 +9,16 @@ data class BidragskalkulatorGrunnlagDto(
     val boOgForbruksutgifter: Map<Int, BigDecimal>,
 
     @field:Schema(description = "Samværsfradrag per aldersintervall")
-    val samværsfradrag: List<SamværsfradragPeriode>
+    val samværsfradrag: List<SamværsfradragPeriode>,
+
+    @field:Schema(
+        description = "Dersom barnets årsinntekt overstiger denne grensen, tas inntekten med i beregningen av barnebidrag."
+    )
+    val barnInntektsgrense: BigDecimal,
+
+    @field:Schema(
+        description = "Årsinntekt over denne grensen medfører at barnet regnes som selvforsørget."
+    )
+    val selvforsørgetBarnInntektsgrense: BigDecimal
+
 )

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/BidragskalkulatorGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/BidragskalkulatorGrunnlagService.kt
@@ -1,19 +1,25 @@
 package no.nav.bidrag.bidragskalkulator.service
 
-import kotlinx.coroutines.coroutineScope
 import no.nav.bidrag.bidragskalkulator.dto.BidragskalkulatorGrunnlagDto
 import org.springframework.stereotype.Service
+import java.math.BigDecimal
 
+private const val ANTALL_FORSKUDDSSATSER_FOR_INNTEKTSPAVIRKNING = 30
+private const val ANTALL_FORSKUDDSSATSER_FOR_SELVFORSORGET_BARN = 100
 
 @Service
 class BidragskalkulatorGrunnlagService(
     private val sjablonService: SjablonService,
-    private val boOgForbruksutgiftService: BoOgForbruksutgiftService
+    private val boOgForbruksutgiftService: BoOgForbruksutgiftService,
 ) {
-    suspend fun hentGrunnlagsData(): BidragskalkulatorGrunnlagDto = coroutineScope {
-        BidragskalkulatorGrunnlagDto(
+    suspend fun hentGrunnlagsData(): BidragskalkulatorGrunnlagDto {
+        val forskuddssats = sjablonService.hentForskuddssats()
+
+        return BidragskalkulatorGrunnlagDto(
             boOgForbruksutgifter = boOgForbruksutgiftService.genererBoOgForbruksutgiftstabell(),
             samværsfradrag = sjablonService.hentSamværsfradrag(),
+            barnInntektsgrense = forskuddssats * BigDecimal(ANTALL_FORSKUDDSSATSER_FOR_INNTEKTSPAVIRKNING),
+            selvforsørgetBarnInntektsgrense = forskuddssats * BigDecimal(ANTALL_FORSKUDDSSATSER_FOR_SELVFORSORGET_BARN),
         )
     }
 }

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/SjablonService.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/SjablonService.kt
@@ -47,6 +47,14 @@ class SjablonService {
         return filtrert
     }
 
+    fun hentForskuddssats(): BigDecimal {
+        logger.info { "Henter forskuddssats fra sjablontall" }
+        val sjablontall = hentSjablontall()
+        val forskuddssats = sjablontall.find { it.typeSjablon == "0005" }?.verdi ?: BigDecimal.ZERO
+        logger.info { "Hentet forskuddssats: $forskuddssats" }
+        return forskuddssats
+    }
+
     /**
      * Henter samværsfradrag fra sjablon, filtrerer på dato og grupperer etter alderTom.
      * Se punktet om Samværsfradrag i https://lovdata.no/nav/rundskriv/v1-55-02

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/BidragskalkulatorGrunnlagControllerTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/BidragskalkulatorGrunnlagControllerTest.kt
@@ -23,13 +23,24 @@ class BidragskalkulatorGrunnlagControllerTest : AbstractControllerTest() {
         every { runBlocking { brukerinformasjonService.hentGrunnlagsData() } } returns
                 BidragskalkulatorGrunnlagDto(
                     boOgForbruksutgifter = emptyMap(),
-                    samværsfradrag = emptyList()
+                    samværsfradrag = emptyList(),
+                    barnInntektsgrense = BigDecimal.ZERO,
+                    selvforsørgetBarnInntektsgrense = BigDecimal.ZERO
                 )
+
+        val expectedJson = """
+            {
+              "boOgForbruksutgifter": {},
+              "samværsfradrag": [],
+              "barnInntektsgrense": 0,
+              "selvforsørgetBarnInntektsgrense": 0
+          }
+        """.trimIndent()
 
         getRequest("/api/v1/bidragskalkulator/grunnlagsdata")
             .andExpect(status().isOk)
             .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-            .andExpect(content().json("""{"boOgForbruksutgifter":{},"samværsfradrag":[]}""", true))
+            .andExpect(content().json(expectedJson, true))
 
         verify(exactly = 1) { runBlocking { brukerinformasjonService.hentGrunnlagsData() } }
     }
@@ -63,7 +74,9 @@ class BidragskalkulatorGrunnlagControllerTest : AbstractControllerTest() {
                             "SAMVÆRSKLASSE_4": 4497
                         }
                     }
-            ]
+            ],
+            "barnInntektsgrense": 60300,
+            "selvforsørgetBarnInntektsgrense": 201000
           }
         """.trimIndent()
 
@@ -85,7 +98,9 @@ class BidragskalkulatorGrunnlagControllerTest : AbstractControllerTest() {
                     "SAMVÆRSKLASSE_3" to BigDecimal(3582),
                     "SAMVÆRSKLASSE_4" to BigDecimal(4497)
                 )),
-            )
+            ),
+            barnInntektsgrense = BigDecimal(60300),
+            selvforsørgetBarnInntektsgrense = BigDecimal(201000)
         )
 
         every { runBlocking { brukerinformasjonService.hentGrunnlagsData() } } returns dto

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/service/BidragskalkulatorGrunnlagServiceTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/service/BidragskalkulatorGrunnlagServiceTest.kt
@@ -22,8 +22,7 @@ class BidragskalkulatorGrunnlagServiceTest {
     )
 
     @Test
-    fun `hentGrunnlagsData returnerer kombinert dto fra begge tjenester`() = runBlocking {
-        // given
+    fun `hentGrunnlagsData returnerer kombinert dto fra alle tjenester`() = runBlocking {
         val underhold = linkedMapOf(
             6 to BigDecimal(6547),
             11 to BigDecimal(7240)
@@ -38,9 +37,12 @@ class BidragskalkulatorGrunnlagServiceTest {
                 )
             )
         )
+        val barnInntektsgrense = BigDecimal(60300)
+        val selvforsørgetBarnInntektsgrense = BigDecimal(201000)
 
         every { boOgForbruksutgiftService.genererBoOgForbruksutgiftstabell() } returns underhold
         every { sjablonService.hentSamværsfradrag() } returns samvaer
+        every { sjablonService.hentForskuddssats() } returns BigDecimal(2010)
 
         // when
         val result: BidragskalkulatorGrunnlagDto = service.hentGrunnlagsData()
@@ -48,15 +50,19 @@ class BidragskalkulatorGrunnlagServiceTest {
         // then
         assertEquals(underhold, result.boOgForbruksutgifter)
         assertEquals(samvaer, result.samværsfradrag)
+        assertEquals(barnInntektsgrense, result.barnInntektsgrense)
+        assertEquals(selvforsørgetBarnInntektsgrense, result.selvforsørgetBarnInntektsgrense)
 
         verify(exactly = 1) { boOgForbruksutgiftService.genererBoOgForbruksutgiftstabell() }
         verify(exactly = 1) { sjablonService.hentSamværsfradrag() }
+        verify(exactly = 1) { sjablonService.hentForskuddssats() }
     }
 
     @Test
     fun `hentGrunnlagsData kaster videre hvis underholdskostnadService feiler`() = runBlocking {
         every { boOgForbruksutgiftService.genererBoOgForbruksutgiftstabell() } throws RuntimeException("Feil")
         every { sjablonService.hentSamværsfradrag() } returns emptyList()
+        every { sjablonService.hentForskuddssats() } returns BigDecimal(2010)
 
         assertThrows<RuntimeException> {
             service.hentGrunnlagsData()
@@ -64,6 +70,7 @@ class BidragskalkulatorGrunnlagServiceTest {
 
         verify(exactly = 1) { boOgForbruksutgiftService.genererBoOgForbruksutgiftstabell() }
         verify(exactly = 0) { sjablonService.hentSamværsfradrag() }
+        verify(exactly = 1) { sjablonService.hentForskuddssats() }
     }
 
     @Test
@@ -72,6 +79,7 @@ class BidragskalkulatorGrunnlagServiceTest {
             6 to BigDecimal(6547)
         )
         every { sjablonService.hentSamværsfradrag() } throws IllegalStateException("sjablon nede")
+        every { sjablonService.hentForskuddssats() } returns BigDecimal(2010)
 
         assertThrows<IllegalStateException> {
             service.hentGrunnlagsData()
@@ -79,5 +87,7 @@ class BidragskalkulatorGrunnlagServiceTest {
 
         verify(exactly = 1) { boOgForbruksutgiftService.genererBoOgForbruksutgiftstabell() }
         verify(exactly = 1) { sjablonService.hentSamværsfradrag() }
+        verify(exactly = 1) { sjablonService.hentForskuddssats() }
+
     }
 }


### PR DESCRIPTION
This pull request extends the data model and service logic for the bidragskalkulator (child support calculator) to include new income thresholds for children, and ensures these are correctly calculated, exposed via the API, and tested. The changes introduce two new fields—`barnInntektsgrense` and `selvforsørgetBarnInntektsgrense`—which are derived from a base "forskuddssats" value, and propagate these additions through DTOs, services, and tests.

**Enhancements to data model and service logic:**

* Added `barnInntektsgrense` and `selvforsørgetBarnInntektsgrense` fields to the `BidragskalkulatorGrunnlagDto` data class, with appropriate schema descriptions.
* Updated `BidragskalkulatorGrunnlagService` to calculate these new fields using a base forskuddssats from `SjablonService`, multiplied by fixed factors, and include them in the returned DTO.
* Added a new method `hentForskuddssats()` in `SjablonService` to retrieve the forskuddssats value needed for the calculations.

**Test updates:**

* Updated controller and service tests to expect and verify the new fields in both the returned DTO and JSON responses, including checks for correct values and error propagation. [[1]](diffhunk://#diff-73ca9cb4e0a837247d7bb80fdf878b2705256ed416aa969d02f8df17488cf11fL26-R43) [[2]](diffhunk://#diff-73ca9cb4e0a837247d7bb80fdf878b2705256ed416aa969d02f8df17488cf11fL66-R79) [[3]](diffhunk://#diff-73ca9cb4e0a837247d7bb80fdf878b2705256ed416aa969d02f8df17488cf11fL88-R103) [[4]](diffhunk://#diff-edadfab11c4d0bee34f901fb67ecdfcb76f93360c08a2b67b031439f7a94d487L25-R25) [[5]](diffhunk://#diff-edadfab11c4d0bee34f901fb67ecdfcb76f93360c08a2b67b031439f7a94d487R40-R73) [[6]](diffhunk://#diff-edadfab11c4d0bee34f901fb67ecdfcb76f93360c08a2b67b031439f7a94d487R82-R91)