### PR TITLE
Bruk beregnV2 for barnebidragsberegning og oppdatér tester

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -1,9 +1,12 @@
 name: Build and deploy
 on:
-  workflow_dispatch: 
+  workflow_dispatch:
   push:
     branches:
       - main
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   build:
     name: Build and publish Docker image

--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.READER_TOKEN }}
 jobs:
   build:
     name: Build and publish Docker image

--- a/.github/workflows/deploy-release.yaml
+++ b/.github/workflows/deploy-release.yaml
@@ -3,7 +3,7 @@ on:
   release:
     types: [published]
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.READER_TOKEN }}
 jobs:
   build:
     name: Build and publish Docker image

--- a/.github/workflows/deploy-release.yaml
+++ b/.github/workflows/deploy-release.yaml
@@ -2,7 +2,8 @@ name: Deploy release to prod
 on:
   release:
     types: [published]
-
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   build:
     name: Build and publish Docker image

--- a/.github/workflows/pr-deploy-comment.yaml
+++ b/.github/workflows/pr-deploy-comment.yaml
@@ -5,7 +5,8 @@ on:
 
 permissions:
   pull-requests: write
-
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   add-comment:
     runs-on: ubuntu-latest
@@ -24,7 +25,7 @@ jobs:
             });
 
             // Sjekk om vi allerede har en deploy-kommentar
-            const harAlleredeLagetDeployKommentar = kommentarer.data.some(kommentar => 
+            const harAlleredeLagetDeployKommentar = kommentarer.data.some(kommentar =>
               kommentar.body.includes('🚀 Deploy til dev-miljø')
             );
 

--- a/.github/workflows/pr-deploy-comment.yaml
+++ b/.github/workflows/pr-deploy-comment.yaml
@@ -6,7 +6,7 @@ on:
 permissions:
   pull-requests: write
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.READER_TOKEN }}
 jobs:
   add-comment:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   test:
     name: Run Tests

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-  packages: read
-
 jobs:
   test:
     name: Run Tests
@@ -24,16 +20,6 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
           cache: gradle
-
-      - name: Cache Gradle dependencies
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle.kts', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-
 
       - name: Run tests
         run: ./gradlew test --no-daemon --stacktrace

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.READER_TOKEN }}
 jobs:
   test:
     name: Run Tests

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -21,5 +21,15 @@ jobs:
           java-version: '21'
           cache: gradle
 
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle.kts', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
       - name: Run tests
         run: ./gradlew test --no-daemon --stacktrace

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     branches:
       - main
-
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   test:
     name: Run Tests

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,13 @@ plugins {
 repositories {
     mavenCentral()
     mavenLocal()
+    maven {
+        url = uri("https://maven.pkg.github.com/navikt/maven-release")
+        credentials {
+            username = "token"
+            password = System.getenv("GITHUB_TOKEN")
+        }
+    }
     maven("https://github-package-registry-mirror.gc.nav.no/cached/maven-release")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,8 @@ version = "0.0.1-SNAPSHOT"
 
 extra["tomcat.version"] = "10.1.47"
 
-val bidragBeregnFellesVersion = "2025.10.15.133314"
-val bidragFellesVersion = "2025.12.16.103515"
+val bidragBeregnFellesVersion = "2026.01.13.144140"
+val bidragFellesVersion = "2026.01.14.133857"
 val kotlinLoggingJvmVersion = "7.0.14"
 val springDocWebmvcVersion = "2.8.13"
 val springmockkVersion = "5.0.1"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,18 +6,18 @@ version = "0.0.1-SNAPSHOT"
 
 extra["tomcat.version"] = "10.1.47"
 
-val bidragBeregnFellesVersion = "2026.01.13.144140"
-val bidragFellesVersion = "2026.01.14.133857"
+val bidragBeregnFellesVersion = "2026.01.28.131946"
+val bidragFellesVersion = "2026.01.30.135639"
 val kotlinLoggingJvmVersion = "7.0.14"
 val springDocWebmvcVersion = "2.8.13"
 val springmockkVersion = "5.0.1"
 val tokenSupportVersion = "5.0.37"
 val jacksonVersion = "2.20.1"
-val junitJupiterVersion = "6.0.1"
+val junitJupiterVersion = "6.0.2"
 val coroutinesVersion = "1.10.2"
 val pdfBoxVersion = "2.0.31"
-val micrometerPrometheusVersion = "1.16.1"
-val logbackVersion = "1.5.23"
+val micrometerPrometheusVersion = "1.16.2"
+val logbackVersion = "1.5.25"
 val logstashEncoderVersion = "9.0"
 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,8 @@ version = "0.0.1-SNAPSHOT"
 
 extra["tomcat.version"] = "10.1.47"
 
-val bidragBeregnFellesVersion = "2026.01.28.131946"
-val bidragFellesVersion = "2026.01.30.135639"
+val bidragBeregnFellesVersion = "2026.02.02.174703"
+val bidragFellesVersion = "2026.02.03.083158"
 val kotlinLoggingJvmVersion = "7.0.14"
 val springDocWebmvcVersion = "2.8.13"
 val springmockkVersion = "5.0.1"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ version = "0.0.1-SNAPSHOT"
 
 extra["tomcat.version"] = "10.1.47"
 
-val bidragBeregnFellesVersion = "2026.02.02.174703"
+val bidragBeregnFellesVersion = "2026.02.03.143635"
 val bidragFellesVersion = "2026.02.03.083158"
 val kotlinLoggingJvmVersion = "7.0.14"
 val springDocWebmvcVersion = "2.8.13"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ repositories {
     maven {
         url = uri("https://maven.pkg.github.com/navikt/maven-release")
         credentials {
-            username = "token"
+            username = "x-access-token"
             password = System.getenv("GITHUB_TOKEN")
         }
     }

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapper.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapper.kt
@@ -32,8 +32,8 @@ class BeregningsgrunnlagMapper(
         val bmTilleggÅrlig = beregnBmTilleggÅrlig(dto)
 
         return dto.barn.mapIndexed { index, barn ->
-            val barnReferanse = barnReferanse(index)
             val fødselsdato = barn.ident.fødselsdato()
+            val barnReferanse = barnReferanse(fødselsdato.toString(), index)
 
             val grunnlagListe = lagGrunnlagsliste(
                 barn = barn,
@@ -56,7 +56,7 @@ class BeregningsgrunnlagMapper(
         val bmTilleggÅrlig = beregnBmTilleggÅrlig(dto)
 
         val grunnlag = dto.barn.mapIndexed { index, barn ->
-            val barnReferanse = barnReferanse(barn.alder)
+            val barnReferanse = barnReferanse(barn.alder.toString(), index)
             val fødselsdato = barn.getEstimertFødselsdato()
 
             val grunnlagListe = lagGrunnlagsliste(
@@ -146,7 +146,7 @@ class BeregningsgrunnlagMapper(
         return BmTilleggÅrlig(kontantstøtteÅrlig, utvidetBarnetrygdÅrlig, småbarnstillegg)
     }
 
-    private fun barnReferanse(alder: Int) = "${SØKNADSBARN}$alder"
+    private fun barnReferanse(alder: String, index: Int) = "${SØKNADSBARN}${alder}_${index}"
 
     private fun byggGrunnlag(referanse: String, type: Grunnlagstype, fødselsdato: LocalDate? = null): GrunnlagDto =
         beregningsgrunnlagBuilder.byggPersongrunnlag(referanse, type, fødselsdato)

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapper.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapper.kt
@@ -25,6 +25,7 @@ class BeregningsgrunnlagMapper(
     companion object Referanser {
         const val BIDRAGSMOTTAKER = "Person_Bidragsmottaker"
         const val BIDRAGSPLIKTIG = "Person_Bidragspliktig"
+        const val SØKNADSBARN = "Person_Søknadsbarn_"
     }
 
     fun mapTilBeregningsgrunnlag(dto: BeregningRequestDto): List<PersonBeregningsgrunnlag> {
@@ -51,11 +52,11 @@ class BeregningsgrunnlagMapper(
         }
     }
 
-    fun mapTilBeregningsgrunnlagAnonym(dto: ÅpenBeregningRequestDto): List<PersonBeregningsgrunnlagAnonym> {
+    fun mapTilBeregningsgrunnlagAnonym(dto: ÅpenBeregningRequestDto): List<BeregnGrunnlag> {
         val bmTilleggÅrlig = beregnBmTilleggÅrlig(dto)
 
         val grunnlag = dto.barn.mapIndexed { index, barn ->
-            val barnReferanse = barnReferanse(index)
+            val barnReferanse = barnReferanse(barn.alder)
             val fødselsdato = barn.getEstimertFødselsdato()
 
             val grunnlagListe = lagGrunnlagsliste(
@@ -66,11 +67,7 @@ class BeregningsgrunnlagMapper(
                 bmTilleggÅrlig = bmTilleggÅrlig
             )
 
-            PersonBeregningsgrunnlagAnonym(
-                alder = barn.alder,
-                bidragsType = dto.bidragstype,
-                grunnlag = beregningsgrunnlagBuilder.byggFellesBeregnGrunnlag(barnReferanse, fødselsdato, grunnlagListe)
-            )
+             beregningsgrunnlagBuilder.byggFellesBeregnGrunnlag(barnReferanse, fødselsdato, grunnlagListe)
         }
 
         return grunnlag
@@ -149,7 +146,7 @@ class BeregningsgrunnlagMapper(
         return BmTilleggÅrlig(kontantstøtteÅrlig, utvidetBarnetrygdÅrlig, småbarnstillegg)
     }
 
-    private fun barnReferanse(index: Int) = "Person_Søknadsbarn_$index"
+    private fun barnReferanse(alder: Int) = "${SØKNADSBARN}$alder"
 
     private fun byggGrunnlag(referanse: String, type: Grunnlagstype, fødselsdato: LocalDate? = null): GrunnlagDto =
         beregningsgrunnlagBuilder.byggPersongrunnlag(referanse, type, fødselsdato)
@@ -191,13 +188,6 @@ data class PersonBeregningsgrunnlag(
     val bidragsType: BidragsType,
     val grunnlag: BeregnGrunnlag,
 )
-
-data class PersonBeregningsgrunnlagAnonym(
-    val alder: Int,
-    val bidragsType: BidragsType,
-    val grunnlag: BeregnGrunnlag,
-)
-
 
 data class BmTilleggÅrlig(
     val kontantstøtteÅrlig: BigDecimal,

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/BeregningService.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/BeregningService.kt
@@ -18,9 +18,12 @@ import no.nav.bidrag.bidragskalkulator.utils.asyncCatching
 import no.nav.bidrag.bidragskalkulator.utils.kalkulerAlder
 import no.nav.bidrag.commons.util.secureLogger
 import no.nav.bidrag.domene.ident.Personident
+import no.nav.bidrag.domene.tid.ÅrMånedsperiode
 import no.nav.bidrag.transport.behandling.beregning.barnebidrag.ResultatPeriode
+import no.nav.bidrag.transport.behandling.beregning.felles.BeregnGrunnlag
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
+import java.time.YearMonth
 import kotlin.time.measureTimedValue
 
 private val logger = KotlinLogging.logger {}
@@ -84,18 +87,18 @@ class BeregningService(
             }.awaitAll()
     }
 
-    private suspend fun utførBarnebidragBeregningAnonym(grunnlag: List<PersonBeregningsgrunnlagAnonym>): List<ÅpenBeregningsresultatBarnDto> =
+    private suspend fun utførBarnebidragBeregningAnonym(grunnlag: List<BeregnGrunnlag>): List<ÅpenBeregningsresultatBarnDto> {
+        val periode = ÅrMånedsperiode(YearMonth.now(), YearMonth.now().plusMonths(1))
+        val beregnet = beregnBarnebidragApi.beregnV2(periode, grunnlag)
 
-            grunnlag.map { data ->
-                    val beregnet = beregnBarnebidragApi.beregn(data.grunnlag)
-                    val sum = summerBeregnedeBeløp(beregnet.beregnetBarnebidragPeriodeListe)
+        return beregnet.map { it ->
+            ÅpenBeregningsresultatBarnDto(
+                sum = summerBeregnedeBeløp(it.beregnetBarnebidragResultat.beregnetBarnebidragPeriodeListe),
+                alder = alderFraBarnReferanse(it.søknadsbarnreferanse) ?: error("Ugyldig barnReferanse: ${it.søknadsbarnreferanse}")
 
-                    ÅpenBeregningsresultatBarnDto(
-                        sum = sum,
-                        alder = data.alder
-                    )
-                }
-
+            )
+        }
+    }
 
     fun beregnPersonUnderholdskostnad(personident: Personident): BigDecimal {
         val alder = kalkulerAlder(personident.fødselsdato())
@@ -139,5 +142,12 @@ class BeregningService(
 
     private fun summerBeregnedeBeløp(periodeListe: List<ResultatPeriode>): BigDecimal =
         periodeListe.sumOf { it.resultat.beløp ?: BigDecimal.ZERO }
+
+    private fun alderFraBarnReferanse(referanse: String): Int? {
+        if (!referanse.startsWith(BeregningsgrunnlagMapper.Referanser.SØKNADSBARN)) return null
+        val rest = referanse.removePrefix(BeregningsgrunnlagMapper.Referanser.SØKNADSBARN)
+        if (rest.isEmpty() || rest.any { !it.isDigit() }) return null
+        return rest.toInt()
+    }
 
 }

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/BeregningService.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/BeregningService.kt
@@ -144,10 +144,16 @@ class BeregningService(
         periodeListe.sumOf { it.resultat.beløp ?: BigDecimal.ZERO }
 
     private fun alderFraBarnReferanse(referanse: String): Int? {
-        if (!referanse.startsWith(BeregningsgrunnlagMapper.Referanser.SØKNADSBARN)) return null
-        val rest = referanse.removePrefix(BeregningsgrunnlagMapper.Referanser.SØKNADSBARN)
-        if (rest.isEmpty() || rest.any { !it.isDigit() }) return null
-        return rest.toInt()
+        val prefix = BeregningsgrunnlagMapper.Referanser.SØKNADSBARN
+        if (!referanse.startsWith(prefix)) return null
+
+        val rest = referanse.removePrefix(prefix)
+        if (rest.isBlank()) return null
+
+        val alderDel = rest.substringBefore('_')
+
+        if (alderDel.isEmpty() || alderDel.any { !it.isDigit() }) return null
+        return alderDel.toInt()
     }
 
 }

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapperTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapperTest.kt
@@ -396,7 +396,7 @@ class BeregningsgrunnlagMapperTest {
 
             val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(request)
 
-            val barnRef = "${BeregningsgrunnlagMapper.Referanser.SØKNADSBARN}${request.barn.first().alder}"
+            val barnRef = "${BeregningsgrunnlagMapper.Referanser.SØKNADSBARN}${request.barn.first().alder}_0"
             val barnInntekt = result.first().grunnlagListe
                 .find { it.referanse == "${BeregningsgrunnlagKonstant.INNTEKT_PREFIX}$barnRef" }
 
@@ -546,7 +546,7 @@ class BeregningsgrunnlagMapperTest {
             val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(request)
             val grunnlag = result.first().grunnlagListe
 
-            val barnRef = "${BeregningsgrunnlagMapper.Referanser.SØKNADSBARN}${request.barn.first().alder}"
+            val barnRef = "${BeregningsgrunnlagMapper.Referanser.SØKNADSBARN}${request.barn.first().alder}_0"
 
             // Mapperen skal alltid legge inn disse to bostatusene:
             assertThat(grunnlag).anyMatch { it.referanse == BeregningsgrunnlagKonstant.BOSTATUS_BIDRAGSPLIKTIG }
@@ -604,6 +604,6 @@ class BeregningsgrunnlagMapperTest {
         index: Int
     ) {
         val forventetAlder = beregningRequest.barn[index].alder
-        assertEquals("${BeregningsgrunnlagMapper.Referanser.SØKNADSBARN}$forventetAlder", grunnlag.søknadsbarnReferanse)
+        assertEquals("${BeregningsgrunnlagMapper.Referanser.SØKNADSBARN}${forventetAlder}_${index}", grunnlag.søknadsbarnReferanse)
     }
 }

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapperTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapperTest.kt
@@ -9,7 +9,6 @@ import no.nav.bidrag.bidragskalkulator.dto.ForelderInntektDto
 import no.nav.bidrag.bidragskalkulator.dto.KontantstøtteDto
 import no.nav.bidrag.bidragskalkulator.dto.UtvidetBarnetrygdDto
 import no.nav.bidrag.bidragskalkulator.dto.åpenBeregning.ÅpenBeregningRequestDto
-import no.nav.bidrag.bidragskalkulator.service.PersonService
 import no.nav.bidrag.bidragskalkulator.service.SjablonService
 import no.nav.bidrag.bidragskalkulator.utils.lagBarnDto
 import no.nav.bidrag.bidragskalkulator.utils.lagBeregningRequestDto
@@ -19,12 +18,13 @@ import no.nav.bidrag.domene.enums.barnetilsyn.Tilsynstype
 import no.nav.bidrag.domene.enums.beregning.Samværsklasse
 import no.nav.bidrag.domene.enums.grunnlag.Grunnlagstype
 import no.nav.bidrag.domene.enums.vedtak.Stønadstype
-import no.nav.bidrag.generer.testdata.person.genererPersonident
+import no.nav.bidrag.transport.behandling.beregning.felles.BeregnGrunnlag
 import no.nav.bidrag.transport.behandling.felles.grunnlag.InntektsrapporteringPeriode
 import no.nav.bidrag.transport.behandling.felles.grunnlag.innholdTilObjekt
-import no.nav.bidrag.transport.person.PersonDto
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -35,11 +35,8 @@ import java.time.LocalDate
 @ExtendWith(MockKExtension::class)
 class BeregningsgrunnlagMapperTest {
 
-    @MockK(relaxed = true)
-    lateinit var mockPersonService: PersonService
-
     // Bruk ekte builder
-    private val mockBeregningsgrunnlagBuilder = BeregningsgrunnlagBuilder()
+    private val beregningsgrunnlagBuilder = BeregningsgrunnlagBuilder()
 
     @MockK
     lateinit var sjablonService: SjablonService
@@ -48,24 +45,14 @@ class BeregningsgrunnlagMapperTest {
 
     @BeforeEach
     fun setup() {
-        val fødselsdato = LocalDate.now().minusYears(10)
-
-        every { mockPersonService.hentPersoninformasjon(any()) } returns PersonDto(
-            fødselsdato = fødselsdato,
-            ident = genererPersonident(),
-            fornavn = "Navn",
-            visningsnavn = "Navn Navnesen",
-        )
-
         every { sjablonService.hentSjablontall() } returns emptyList()
-
-        beregningsgrunnlagMapper = BeregningsgrunnlagMapper(mockBeregningsgrunnlagBuilder, sjablonService)
+        beregningsgrunnlagMapper = BeregningsgrunnlagMapper(beregningsgrunnlagBuilder, sjablonService)
     }
 
     @Test
     fun `mapTilBoOgForbruksutgiftsgrunnlag skal bygge grunnlag med BM BP og søknadsbarn`() {
         val fødselsdato = LocalDate.now().minusYears(5)
-        val barnRef = "Person_Søknadsbarn_0"
+        val barnRef = "${BeregningsgrunnlagMapper.Referanser.SØKNADSBARN}1"
 
         val result = beregningsgrunnlagMapper.mapTilBoOgForbruksutgiftsgrunnlag(fødselsdato, barnRef)
 
@@ -80,7 +67,7 @@ class BeregningsgrunnlagMapperTest {
     }
 
     @Test
-    fun `skal mappe BeregningRequestDto med ett barn til BeregnGrunnlag`() {
+    fun `skal mappe ÅpenBeregningRequestDto med ett barn til BeregnGrunnlag`() {
         val beregningRequest = lagBeregningRequestDto(
             bmInntekt = ForelderInntektDto(BigDecimal("300000")),
             bpInntekt = ForelderInntektDto(BigDecimal("700000")),
@@ -95,7 +82,7 @@ class BeregningsgrunnlagMapperTest {
     }
 
     @Test
-    fun `skal mappe BeregningRequestDto med to barn til BeregnGrunnlag`() {
+    fun `skal mappe ÅpenBeregningRequestDto med to barn til BeregnGrunnlag`() {
         val barn1 = lagBarnDto(alder = 1)
         val barn2 = lagBarnDto(alder = 2)
         val beregningRequest = lagBeregningRequestDto(
@@ -108,8 +95,8 @@ class BeregningsgrunnlagMapperTest {
         val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(beregningRequest)
 
         assertEquals(2, result.size, "Forventet to beregninger")
-        result.forEachIndexed { index, beregnGrunnlagMedAlder ->
-            assertBarnetsAlderOgReferanse(beregnGrunnlagMedAlder, beregningRequest, index)
+        result.forEachIndexed { index, beregnGrunnlag ->
+            assertBarnetsAlderOgReferanse(beregnGrunnlag, beregningRequest, index)
         }
     }
 
@@ -127,7 +114,7 @@ class BeregningsgrunnlagMapperTest {
         val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(beregningRequest)
         // barnsreferanse, bidragspliktigsreferanse, bidragsmottakersreferanse, bidragspliktig inntekt,
         // bidragsmottaker inntekt, samværsklasse, bidragspliktig bostatus, barn bostatus
-        assertEquals(8, result.first().grunnlag.grunnlagListe.size, "Forventet 8 grunnlagselementer")
+        assertEquals(8, result.first().grunnlagListe.size, "Forventet 8 grunnlagselementer")
     }
 
     @Nested
@@ -145,7 +132,11 @@ class BeregningsgrunnlagMapperTest {
             val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(beregningRequest)
 
             assertEquals(1, result.size, "Forventet én beregning")
-            assertEquals(Stønadstype.BIDRAG18AAR, result.first().grunnlag.stønadstype, "Stønadstype skal være BIDRAG18AAR for barn over 18")
+            assertEquals(
+                Stønadstype.BIDRAG18AAR,
+                result.first().stønadstype,
+                "Stønadstype skal være BIDRAG18AAR for barn over 18"
+            )
         }
 
         @Test
@@ -157,18 +148,22 @@ class BeregningsgrunnlagMapperTest {
                 bidragstype = BidragsType.MOTTAKER,
                 barn = listOf(barn),
             )
+
             val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(beregningRequest)
 
-            assertEquals(Stønadstype.BIDRAG, result.first().grunnlag.stønadstype)
+            assertEquals(Stønadstype.BIDRAG, result.first().stønadstype)
         }
     }
 
     @Nested
     inner class FaktiskUtgiftBarnetilsyn {
         @Test
-        fun `skal inkludere faktisk utgift grunnlag når brnetilsynsutgift er satt`() {
-            val barn = lagBarnDto(alder = 1, samværklasse = Samværsklasse.SAMVÆRSKLASSE_2, barnetilsyn = BarnetilsynDto(
-                BigDecimal("1200")))
+        fun `skal inkludere faktisk utgift grunnlag når barnetilsynsutgift er satt`() {
+            val barn = lagBarnDto(
+                alder = 1,
+                samværklasse = Samværsklasse.SAMVÆRSKLASSE_2,
+                barnetilsyn = BarnetilsynDto(BigDecimal("1200"))
+            )
             val beregningRequest = lagBeregningRequestDto(
                 bmInntekt = ForelderInntektDto(BigDecimal("300000")),
                 bpInntekt = ForelderInntektDto(BigDecimal("700000")),
@@ -177,14 +172,14 @@ class BeregningsgrunnlagMapperTest {
             )
 
             val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(beregningRequest)
-            val faktiskUtgiftGrunnlag = result.first().grunnlag.grunnlagListe
+            val faktiskUtgiftGrunnlag = result.first().grunnlagListe
                 .find { it.type == Grunnlagstype.FAKTISK_UTGIFT_PERIODE }
 
             assertNotNull(faktiskUtgiftGrunnlag, "Forventet grunnlag for faktisk utgift til barnetilsyn")
         }
 
         @Test
-        fun `skal ikke inkludere faktisk utgift grunnlag når brnetilsynsutgift ikke er satt`() {
+        fun `skal ikke inkludere faktisk utgift grunnlag når barnetilsynsutgift ikke er satt`() {
             val beregningRequest = lagBeregningRequestDto(
                 bmInntekt = ForelderInntektDto(BigDecimal("300000")),
                 bpInntekt = ForelderInntektDto(BigDecimal("700000")),
@@ -193,18 +188,23 @@ class BeregningsgrunnlagMapperTest {
             )
 
             val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(beregningRequest)
-            val faktiskUtgiftGrunnlag = result.first().grunnlag.grunnlagListe
+            val faktiskUtgiftGrunnlag = result.first().grunnlagListe
                 .find { it.type == Grunnlagstype.FAKTISK_UTGIFT_PERIODE }
 
-            assertNull(faktiskUtgiftGrunnlag, "Forventet ikke grunnlag for faktisk utgift til barnetilsyn når barnetilsynsutgift ikke er satt")
+            assertNull(
+                faktiskUtgiftGrunnlag,
+                "Forventet ikke grunnlag for faktisk utgift til barnetilsyn når barnetilsynsutgift ikke er satt"
+            )
         }
 
         @Test
         fun `skal legge til grunnlag for mottatt barnepassplass når barnetilsyn plassType er satt`() {
-            val barn = lagBarnDto(barnetilsyn = BarnetilsynDto(
-                månedligUtgift = null,
-                plassType = Tilsynstype.DELTID,
-            ))
+            val barn = lagBarnDto(
+                barnetilsyn = BarnetilsynDto(
+                    månedligUtgift = null,
+                    plassType = Tilsynstype.DELTID,
+                )
+            )
             val request = lagBeregningRequestDto(
                 bmInntekt = ForelderInntektDto(BigDecimal("300000")),
                 bpInntekt = ForelderInntektDto(BigDecimal("700000")),
@@ -214,10 +214,10 @@ class BeregningsgrunnlagMapperTest {
 
             val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(request)
 
-            val barnetilsynMedStønadGrunnlag = result.first().grunnlag.grunnlagListe
+            val barnetilsynMedStønadGrunnlag = result.first().grunnlagListe
                 .find { it.type == Grunnlagstype.BARNETILSYN_MED_STØNAD_PERIODE }
 
-            val faktiskUtgiftGrunnlag = result.first().grunnlag.grunnlagListe
+            val faktiskUtgiftGrunnlag = result.first().grunnlagListe
                 .find { it.type == Grunnlagstype.FAKTISK_UTGIFT_PERIODE }
 
             assertNotNull(barnetilsynMedStønadGrunnlag)
@@ -236,10 +236,10 @@ class BeregningsgrunnlagMapperTest {
 
             val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(request)
 
-            val barnetilsynMedStønadGrunnlag = result.first().grunnlag.grunnlagListe
+            val barnetilsynMedStønadGrunnlag = result.first().grunnlagListe
                 .find { it.type == Grunnlagstype.BARNETILSYN_MED_STØNAD_PERIODE }
 
-            val faktiskUtgiftGrunnlag = result.first().grunnlag.grunnlagListe
+            val faktiskUtgiftGrunnlag = result.first().grunnlagListe
                 .find { it.type == Grunnlagstype.FAKTISK_UTGIFT_PERIODE }
 
             assertNull(barnetilsynMedStønadGrunnlag)
@@ -264,10 +264,9 @@ class BeregningsgrunnlagMapperTest {
 
             // kontantstøtteTilleggBm = 100 * 12
             val forventetTilleggÅr = BigDecimal("100").multiply(BigDecimal("12"))
-
             val forventetBmInntekt = beregningRequest.bidragsmottakerInntekt.inntekt + forventetTilleggÅr
 
-            val inntektBmGrunnlag = result.first().grunnlag.grunnlagListe
+            val inntektBmGrunnlag = result.first().grunnlagListe
                 .first { it.referanse == BeregningsgrunnlagKonstant.INNTEKT_BIDRAGSMOTTAKER }
 
             val beløp = inntektBmGrunnlag.innholdTilObjekt<InntektsrapporteringPeriode>().beløp
@@ -288,11 +287,12 @@ class BeregningsgrunnlagMapperTest {
             )
 
             val resultDelt = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(requestDelt)
-            val bmInntektDelt = resultDelt.first().grunnlag.grunnlagListe
+            val bmInntektDelt = resultDelt.first().grunnlagListe
                 .first { it.referanse == BeregningsgrunnlagKonstant.INNTEKT_BIDRAGSMOTTAKER }
                 .innholdTilObjekt<InntektsrapporteringPeriode>().beløp
 
-            val forventetDelt = requestDelt.bidragsmottakerInntekt.inntekt + beløp.multiply(BigDecimal("12")).divide(BigDecimal("2"))
+            val forventetDelt =
+                requestDelt.bidragsmottakerInntekt.inntekt + beløp.multiply(BigDecimal("12")).divide(BigDecimal("2"))
             assertThat(bmInntektDelt).isEqualByComparingTo(forventetDelt)
 
             // deles = false
@@ -305,7 +305,7 @@ class BeregningsgrunnlagMapperTest {
             )
 
             val resultFull = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(requestFull)
-            val bmInntektFull = resultFull.first().grunnlag.grunnlagListe
+            val bmInntektFull = resultFull.first().grunnlagListe
                 .first { it.referanse == BeregningsgrunnlagKonstant.INNTEKT_BIDRAGSMOTTAKER }
                 .innholdTilObjekt<InntektsrapporteringPeriode>().beløp
 
@@ -328,7 +328,7 @@ class BeregningsgrunnlagMapperTest {
 
             // 0032 = småbarnstillegg per måned
             every { sjablonService.hentSjablontall() } returns listOf(
-                no.nav.bidrag.commons.service.sjablon.Sjablontall(
+                Sjablontall(
                     typeSjablon = "0032",
                     verdi = BigDecimal("1500"),
                     datoFom = null,
@@ -338,7 +338,7 @@ class BeregningsgrunnlagMapperTest {
 
             val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(beregningRequest)
 
-            val beløp = result.first().grunnlag.grunnlagListe
+            val beløp = result.first().grunnlagListe
                 .first { it.referanse == BeregningsgrunnlagKonstant.INNTEKT_BIDRAGSMOTTAKER }
                 .innholdTilObjekt<InntektsrapporteringPeriode>()
                 .beløp
@@ -361,7 +361,7 @@ class BeregningsgrunnlagMapperTest {
 
             // Sjablon finnes, men skal IKKE brukes når flagget er false
             every { sjablonService.hentSjablontall() } returns listOf(
-                no.nav.bidrag.commons.service.sjablon.Sjablontall(
+                Sjablontall(
                     typeSjablon = "0032",
                     verdi = BigDecimal("1500"),
                     datoFom = null,
@@ -371,7 +371,7 @@ class BeregningsgrunnlagMapperTest {
 
             val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(request)
 
-            val beløp = result.first().grunnlag.grunnlagListe
+            val beløp = result.first().grunnlagListe
                 .first { it.referanse == BeregningsgrunnlagKonstant.INNTEKT_BIDRAGSMOTTAKER }
                 .innholdTilObjekt<InntektsrapporteringPeriode>()
                 .beløp
@@ -396,8 +396,8 @@ class BeregningsgrunnlagMapperTest {
 
             val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(request)
 
-            val barnRef = "Person_Søknadsbarn_0"
-            val barnInntekt = result.first().grunnlag.grunnlagListe
+            val barnRef = "${BeregningsgrunnlagMapper.Referanser.SØKNADSBARN}${request.barn.first().alder}"
+            val barnInntekt = result.first().grunnlagListe
                 .find { it.referanse == "${BeregningsgrunnlagKonstant.INNTEKT_PREFIX}$barnRef" }
 
             assertNotNull(barnInntekt)
@@ -416,8 +416,8 @@ class BeregningsgrunnlagMapperTest {
 
             val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(request)
 
-            val barnRef = "Person_Søknadsbarn_0"
-            val barnInntekt = result.first().grunnlag.grunnlagListe
+            val barnRef = "${BeregningsgrunnlagMapper.Referanser.SØKNADSBARN}${request.barn.first().alder}"
+            val barnInntekt = result.first().grunnlagListe
                 .find { it.referanse == "${BeregningsgrunnlagKonstant.INNTEKT_PREFIX}$barnRef" }
 
             assertNull(barnInntekt)
@@ -450,7 +450,7 @@ class BeregningsgrunnlagMapperTest {
 
             val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(request)
 
-            val bmBeløp = result.first().grunnlag.grunnlagListe
+            val bmBeløp = result.first().grunnlagListe
                 .first { it.referanse == BeregningsgrunnlagKonstant.INNTEKT_BIDRAGSMOTTAKER }
                 .innholdTilObjekt<InntektsrapporteringPeriode>()
                 .beløp
@@ -483,7 +483,7 @@ class BeregningsgrunnlagMapperTest {
 
             val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(beregningRequest)
 
-            val inntektBmGrunnlag = result.first().grunnlag.grunnlagListe
+            val inntektBmGrunnlag = result.first().grunnlagListe
                 .first { it.referanse == BeregningsgrunnlagKonstant.INNTEKT_BIDRAGSMOTTAKER }
 
             val beløp = inntektBmGrunnlag.innholdTilObjekt<InntektsrapporteringPeriode>().beløp
@@ -518,7 +518,7 @@ class BeregningsgrunnlagMapperTest {
 
             val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(beregningRequest)
 
-            val beløp = result.first().grunnlag.grunnlagListe
+            val beløp = result.first().grunnlagListe
                 .first { it.referanse == BeregningsgrunnlagKonstant.INNTEKT_BIDRAGSMOTTAKER }
                 .innholdTilObjekt<InntektsrapporteringPeriode>()
                 .beløp
@@ -544,11 +544,13 @@ class BeregningsgrunnlagMapperTest {
             )
 
             val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(request)
-            val grunnlag = result.first().grunnlag.grunnlagListe
+            val grunnlag = result.first().grunnlagListe
+
+            val barnRef = "${BeregningsgrunnlagMapper.Referanser.SØKNADSBARN}${request.barn.first().alder}"
 
             // Mapperen skal alltid legge inn disse to bostatusene:
             assertThat(grunnlag).anyMatch { it.referanse == BeregningsgrunnlagKonstant.BOSTATUS_BIDRAGSPLIKTIG }
-            assertThat(grunnlag).anyMatch { it.referanse == "${BeregningsgrunnlagKonstant.BOSTATUS_BARN_PREFIX}Person_Søknadsbarn_0" }
+            assertThat(grunnlag).anyMatch { it.referanse == "${BeregningsgrunnlagKonstant.BOSTATUS_BARN_PREFIX}$barnRef" }
         }
 
         @Test
@@ -562,10 +564,12 @@ class BeregningsgrunnlagMapperTest {
                 dittBoforhold = lagBoforhold(antallBarnUnder18BorFast = 0),
             )
 
-            val grunnlag = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(request).first().grunnlag.grunnlagListe
+            val grunnlag = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(request).first().grunnlagListe
 
             val under18BorFast = grunnlag.filter {
-                it.referanse.startsWith("${BeregningsgrunnlagKonstant.BOSTATUS_BARN_PREFIX}${BeregningsgrunnlagKonstant.BOSTATUS_EGNE_BARN_UNDER18_BOR_FAST}")
+                it.referanse.startsWith(
+                    "${BeregningsgrunnlagKonstant.BOSTATUS_BARN_PREFIX}${BeregningsgrunnlagKonstant.BOSTATUS_EGNE_BARN_UNDER18_BOR_FAST}"
+                )
             }
 
             assertThat(under18BorFast).hasSize(2)
@@ -582,10 +586,12 @@ class BeregningsgrunnlagMapperTest {
                 medforelderBoforhold = lagBoforhold(antallBarnUnder18BorFast = 0),
             )
 
-            val grunnlag = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(request).first().grunnlag.grunnlagListe
+            val grunnlag = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(request).first().grunnlagListe
 
             val under18BorFast = grunnlag.filter {
-                it.referanse.startsWith("${BeregningsgrunnlagKonstant.BOSTATUS_BARN_PREFIX}${BeregningsgrunnlagKonstant.BOSTATUS_EGNE_BARN_UNDER18_BOR_FAST}")
+                it.referanse.startsWith(
+                    "${BeregningsgrunnlagKonstant.BOSTATUS_BARN_PREFIX}${BeregningsgrunnlagKonstant.BOSTATUS_EGNE_BARN_UNDER18_BOR_FAST}"
+                )
             }
 
             assertThat(under18BorFast).hasSize(3)
@@ -593,11 +599,11 @@ class BeregningsgrunnlagMapperTest {
     }
 
     private fun assertBarnetsAlderOgReferanse(
-    grunnlagOgBarnInformasjon: PersonBeregningsgrunnlagAnonym,
-    beregningRequest: ÅpenBeregningRequestDto,
-    index: Int
+        grunnlag: BeregnGrunnlag,
+        beregningRequest: ÅpenBeregningRequestDto,
+        index: Int
     ) {
-        assertEquals(beregningRequest.barn[index].alder, grunnlagOgBarnInformasjon.alder)
-        assertEquals("Person_Søknadsbarn_$index", grunnlagOgBarnInformasjon.grunnlag.søknadsbarnReferanse)
+        val forventetAlder = beregningRequest.barn[index].alder
+        assertEquals("${BeregningsgrunnlagMapper.Referanser.SØKNADSBARN}$forventetAlder", grunnlag.søknadsbarnReferanse)
     }
 }

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/service/BeregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/service/BeregningServiceTest.kt
@@ -214,7 +214,7 @@ class BeregningServiceTest {
             )
         }
 
-        coEvery { beregnBarnebidragApi.beregnV2(any(), any(), any(), any()) } returns resultater
+        coEvery { beregnBarnebidragApi.beregnV2(any(), any()) } returns resultater
 
         return beregningRequest
     }

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/service/BeregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/service/BeregningServiceTest.kt
@@ -1,3 +1,6 @@
+package no.nav.bidrag.bidragskalkulator.service
+
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
@@ -10,16 +13,13 @@ import no.nav.bidrag.bidragskalkulator.dto.åpenBeregning.ÅpenBeregningsresulta
 import no.nav.bidrag.bidragskalkulator.mapper.BeregningsgrunnlagBuilder
 import no.nav.bidrag.bidragskalkulator.mapper.BeregningsgrunnlagMapper
 import no.nav.bidrag.bidragskalkulator.mapper.tilFamilieRelasjon
-import no.nav.bidrag.bidragskalkulator.service.BeregningService
-import no.nav.bidrag.bidragskalkulator.service.BoOgForbruksutgiftService
-import no.nav.bidrag.bidragskalkulator.service.PersonService
-import no.nav.bidrag.bidragskalkulator.service.SjablonService
 import no.nav.bidrag.bidragskalkulator.utils.JsonUtils
 import no.nav.bidrag.bidragskalkulator.utils.kalkulerAlder
 import no.nav.bidrag.domene.enums.beregning.Samværsklasse
 import no.nav.bidrag.domene.tid.ÅrMånedsperiode
 import no.nav.bidrag.generer.testdata.person.genererPersonident
 import no.nav.bidrag.transport.behandling.beregning.barnebidrag.BeregnetBarnebidragResultat
+import no.nav.bidrag.transport.behandling.beregning.barnebidrag.BeregnetBarnebidragResultatV2
 import no.nav.bidrag.transport.behandling.beregning.barnebidrag.ResultatBeregning
 import no.nav.bidrag.transport.behandling.beregning.barnebidrag.ResultatPeriode
 import no.nav.bidrag.transport.person.MotpartBarnRelasjonDto
@@ -65,8 +65,9 @@ class BeregningServiceTest {
 
         @BeforeEach
         fun oppsett() = runTest {
-            // beregne for et barn
-            beregningRequest = mockOppsett(listOf(BarnMedAlderDto(alder = 1, samværsklasse = Samværsklasse.SAMVÆRSKLASSE_2)))
+            beregningRequest = mockOppsett(
+                listOf(BarnMedAlderDto(alder = 1, samværsklasse = Samværsklasse.SAMVÆRSKLASSE_2))
+            )
             beregningResultat = beregningService.beregnBarnebidragAnonym(beregningRequest)
         }
 
@@ -79,6 +80,9 @@ class BeregningServiceTest {
                 barn = emptyList()
             )
 
+            // Ny service kaller beregnV2(periode, grunnlagSøknadsbarnListe, grunnlagLøpendeBidragListe, grunnlagPrivatAvtaleListe)
+            coEvery { beregnBarnebidragApi.beregnV2(any(), any(), any(), any()) } returns emptyList()
+
             val resultat = beregningService.beregnBarnebidragAnonym(beregningRequest)
 
             assertEquals(true, resultat.resultater.isEmpty())
@@ -87,6 +91,11 @@ class BeregningServiceTest {
         @Test
         fun `skal returnere ett beregningsresultat for ett barn`() {
             assertEquals(1, beregningResultat.resultater.size)
+        }
+
+        @Test
+        fun `skal returnere alder fra søknadsbarnreferanse`() {
+            assertEquals(1, beregningResultat.resultater.first().alder)
         }
     }
 
@@ -98,10 +107,12 @@ class BeregningServiceTest {
 
         @BeforeEach
         fun oppsett() = runTest {
-            beregningRequest = mockOppsett(listOf(
-                BarnMedAlderDto(alder = 4, samværsklasse = Samværsklasse.SAMVÆRSKLASSE_2),
-                BarnMedAlderDto(alder = 7, samværsklasse = Samværsklasse.SAMVÆRSKLASSE_3)
-            ))
+            beregningRequest = mockOppsett(
+                listOf(
+                    BarnMedAlderDto(alder = 4, samværsklasse = Samværsklasse.SAMVÆRSKLASSE_2),
+                    BarnMedAlderDto(alder = 7, samværsklasse = Samværsklasse.SAMVÆRSKLASSE_3)
+                )
+            )
             beregningResultat = beregningService.beregnBarnebidragAnonym(beregningRequest)
         }
 
@@ -109,6 +120,12 @@ class BeregningServiceTest {
         fun `skal returnere to beregningsresultater for to barn`() = runTest {
             val resultat = beregningService.beregnBarnebidragAnonym(beregningRequest)
             assertEquals(2, resultat.resultater.size)
+        }
+
+        @Test
+        fun `skal mappe alder riktig for begge barn`() {
+            val aldre = beregningResultat.resultater.map { it.alder }.sorted()
+            assertEquals(listOf(4, 7), aldre)
         }
     }
 
@@ -138,22 +155,16 @@ class BeregningServiceTest {
 
         @Test
         fun `skal beregne underholdskostnader for barnerelasjoner og sortere etter alder`() = runTest {
-            // Arrange
             val motpartBarnRelasjon: MotpartBarnRelasjonDto = JsonUtils.lesJsonFil("/person/person_med_barn_en_motpart.json")
             val fellesBarn = motpartBarnRelasjon.personensMotpartBarnRelasjon.first().fellesBarn
 
-            val barn1Ident = fellesBarn[0].ident
-            val barn2Ident = fellesBarn[1].ident
             val forventetUnderholdskostnad = BigDecimal(8471)
+            every { boOgForbruksutgiftServiceMock.beregnCachedPersonBoOgForbruksutgiftskostnad(any()) } returns forventetUnderholdskostnad
 
-            every { boOgForbruksutgiftServiceMock.beregnCachedPersonBoOgForbruksutgiftskostnad(any()) } returns BigDecimal.ZERO
-            every { beregningService.beregnPersonUnderholdskostnad(barn1Ident) } returns forventetUnderholdskostnad
-            every { beregningService.beregnPersonUnderholdskostnad(barn2Ident) } returns forventetUnderholdskostnad
+            val resultat = beregningService.beregnUnderholdskostnaderForBarnerelasjoner(
+                motpartBarnRelasjon.personensMotpartBarnRelasjon.tilFamilieRelasjon()
+            )
 
-            // Act
-            val resultat = beregningService.beregnUnderholdskostnaderForBarnerelasjoner(motpartBarnRelasjon.personensMotpartBarnRelasjon.tilFamilieRelasjon())
-
-            // Assert
             assertEquals(1, resultat.size, "Skal være én relasjon til motpart med barn")
 
             val relasjon = resultat.first()
@@ -165,11 +176,10 @@ class BeregningServiceTest {
                 .sortedDescending()
 
             val faktiskeAldre = relasjon.fellesBarn.map { it.alder }
-
             assertEquals(forventetSortertAldre, faktiskeAldre, "Barna skal være sortert etter alder synkende")
 
-            assertEquals(BigDecimal(8471), relasjon.fellesBarn[0].underholdskostnad)
-            assertEquals(BigDecimal(8471), relasjon.fellesBarn[1].underholdskostnad)
+            assertEquals(forventetUnderholdskostnad, relasjon.fellesBarn[0].underholdskostnad)
+            assertEquals(forventetUnderholdskostnad, relasjon.fellesBarn[1].underholdskostnad)
         }
     }
 
@@ -197,9 +207,14 @@ class BeregningServiceTest {
             beregnetBarnebidragPeriodeListe = listOf(lagResultatPeriode())
         )
 
-        beregningRequest.barn.forEach { _ ->
-            every { beregnBarnebidragApi.beregn(any()) } returns beregnetResultat
+        val resultater: List<BeregnetBarnebidragResultatV2> = barn.map { b ->
+            BeregnetBarnebidragResultatV2(
+                søknadsbarnreferanse = "${BeregningsgrunnlagMapper.Referanser.SØKNADSBARN}${b.alder}",
+                beregnetBarnebidragResultat = beregnetResultat
+            )
         }
+
+        coEvery { beregnBarnebidragApi.beregnV2(any(), any(), any(), any()) } returns resultater
 
         return beregningRequest
     }

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/service/BeregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/service/BeregningServiceTest.kt
@@ -80,8 +80,7 @@ class BeregningServiceTest {
                 barn = emptyList()
             )
 
-            // Ny service kaller beregnV2(periode, grunnlagSøknadsbarnListe, grunnlagLøpendeBidragListe, grunnlagPrivatAvtaleListe)
-            coEvery { beregnBarnebidragApi.beregnV2(any(), any(), any(), any()) } returns emptyList()
+            coEvery { beregnBarnebidragApi.beregnV2(any(), any()) } returns emptyList()
 
             val resultat = beregningService.beregnBarnebidragAnonym(beregningRequest)
 
@@ -110,6 +109,7 @@ class BeregningServiceTest {
             beregningRequest = mockOppsett(
                 listOf(
                     BarnMedAlderDto(alder = 4, samværsklasse = Samværsklasse.SAMVÆRSKLASSE_2),
+                    BarnMedAlderDto(alder = 4, samværsklasse = Samværsklasse.SAMVÆRSKLASSE_2),
                     BarnMedAlderDto(alder = 7, samværsklasse = Samværsklasse.SAMVÆRSKLASSE_3)
                 )
             )
@@ -119,13 +119,13 @@ class BeregningServiceTest {
         @Test
         fun `skal returnere to beregningsresultater for to barn`() = runTest {
             val resultat = beregningService.beregnBarnebidragAnonym(beregningRequest)
-            assertEquals(2, resultat.resultater.size)
+            assertEquals(3, resultat.resultater.size)
         }
 
         @Test
-        fun `skal mappe alder riktig for begge barn`() {
+        fun `skal mappe alder riktig for alle barn og kunne håndtere barn med samme alder`() {
             val aldre = beregningResultat.resultater.map { it.alder }.sorted()
-            assertEquals(listOf(4, 7), aldre)
+            assertEquals(listOf(4, 4, 7), aldre)
         }
     }
 


### PR DESCRIPTION
	•	Bytter fra beregn(...) til beregnV2(...) ved anonym beregning av barnebidrag.
	•	Mapper nå anonymt beregningsgrunnlag direkte til List<BeregnGrunnlag>.
	•	Bruker søknadsbarnReferanse på formatet Person_Søknadsbarn_<alder> for å kunne hente alder direkte fra beregningsresultatet.
	•	Oppdatert BeregningsgrunnlagMapper og BeregningService i tråd med ny V2-flyt.
	•	Refaktorert og oppdatert enhetstester for både mapper og service slik at de:
	•	støtter V2-APIet
	•	håndterer flere barn i samme beregning
	•	verifiserer korrekt mapping av alder og summer