### PR TITLE
Bruk fødselsdato i stedet for alder

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -116,7 +116,7 @@ dependencies {
     testImplementation("no.nav.security:token-validation-spring-test:$tokenSupportVersion")
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion")
-
+    testImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 }
 
 java {

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/config/SwaggerConfig.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/config/SwaggerConfig.kt
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.models.media.Schema
 import no.nav.bidrag.bidragskalkulator.dto.BidragsType
 import no.nav.bidrag.bidragskalkulator.dto.Oppgjørsform
 import no.nav.bidrag.bidragskalkulator.dto.Vedleggskrav
+import no.nav.bidrag.bidragskalkulator.dto.VoksneOver18Type
 import no.nav.bidrag.bidragskalkulator.dto.førstesidegenerator.NavSkjemaId
 import no.nav.bidrag.bidragskalkulator.dto.førstesidegenerator.Språkkode
 import no.nav.bidrag.domene.enums.barnetilsyn.Tilsynstype
@@ -84,6 +85,12 @@ class SwaggerConfig {
                     enum = BidragsType.entries.map { it.name }
                 }
 
+            val voksneOver18TypeSchema = Schema<String>().description("Type voksne over 18 år i husholdningen")
+                .example("SAMBOER_ELLER_EKTEFELLE")
+                .apply {
+                    enum = VoksneOver18Type.entries.map { it.name }
+                }
+
             openApi.components = (openApi.components ?: Components())
                 .addSchemas("Samværsklasse", samværsklasseSchema)
                 .addSchemas("Tilsynstype", tilsynstypeSchema)
@@ -92,6 +99,7 @@ class SwaggerConfig {
                 .addSchemas("Språkkode", språkkodeSchema)
                 .addSchemas("NavSkjemaId", navSkjemaIdSchema)
                 .addSchemas("bidragsTypeSchema", bidragsTypeSchema)
+                .addSchemas("voksneOver18TypeSchema", voksneOver18TypeSchema)
         }
     }
 }

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/BeregningRequestDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/BeregningRequestDto.kt
@@ -163,10 +163,7 @@ data class BoforholdDto(
     @param:Schema(description = "Antall barn under 18 år som bor fast hos forelderen", required = true, example = "3")
     val antallBarnUnder18BorFast: Int,
 
-    @param:Schema(
-        description = "Typer voksne over 18 år i husholdningen (kan være null).",
-        required = false
-    )
+    @param:Schema(ref = "#/components/schemas/voksneOver18TypeSchema")
     val voksneOver18Type: Set<VoksneOver18Type>? = null,
 
     @field:Min(0)

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/åpenBeregning/ÅpenBeregningRequestDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/åpenBeregning/ÅpenBeregningRequestDto.kt
@@ -14,12 +14,10 @@ import java.math.BigDecimal
 import java.time.LocalDate
 
 @Schema(description = "Informasjon om et barn i beregningen")
-data class BarnMedAlderDto(
-    @field:NotNull(message = "Alder må være satt")
-    @field:Min(value = 0, message = "Alder kan ikke være negativ")
-    @field:Max(value = 25, message = "Alder kan ikke være høyere enn 25")
-    @param:Schema(description = "Alder til barnet", required = true, example = "10")
-    val alder: Int,
+data class BarnMedFødselsdatoDto(
+    @field:NotNull(message = "Fødselsdato må være satt")
+    @param:Schema(description = "Fødselsdato til barnet", required = true, example = "2015-06-30")
+    val fødselsdato: LocalDate,
 
     @field:NotNull(message = "Samværsklasse må være satt")
     @param:Schema(ref = "#/components/schemas/Samværsklasse") // Reference dynamically registered schema. See BeregnBarnebidragConfig
@@ -49,10 +47,14 @@ data class BarnMedAlderDto(
 ): IFellesBarnDto {
     @JsonIgnore
     @Schema(hidden = true) // Hides from Swagger
-    //Når barnet har alder = 15, blir fødselsmåneden alltid satt til juli, uavhengig av den faktiske fødselsdatoen (usikkert hvor denne regelen stammer fra).
-    // Dette betyr at barnet ikke anses som 15 år før juli.
-    // I alle beregningsperioder før juli vil barnet derfor fortsatt regnes som 14 år.
-    fun getEstimertFødselsdato(): LocalDate = LocalDate.now().minusYears(alder.toLong())
+    fun getAlder(): Int = LocalDate.now().year - fødselsdato.year
+
+    @JsonIgnore
+    @Schema(hidden = true)
+    fun getAntallMåneder(): Int {
+        val today = LocalDate.now()
+        return (today.year - fødselsdato.year) * 12 + (today.monthValue - fødselsdato.monthValue)
+    }
 }
 
 @Schema(description = "Modellen brukes til å beregne barnebidrag basert på barnets alder")
@@ -60,7 +62,7 @@ data class ÅpenBeregningRequestDto(
     @field:NotEmpty(message = "Liste over barn kan ikke være tom")
     @field:Valid
     @param:Schema(description = "Liste over barn som inngår i beregningen", required = true)
-    override val barn: List<BarnMedAlderDto>,
+    override val barn: List<BarnMedFødselsdatoDto>,
 
     @param:Schema(description = "Boforhold for den påloggede personen. Må være satt hvis bidragstype for minst ett barn er PLIKTIG", required = false)
     override val dittBoforhold: BoforholdDto? = null,
@@ -103,6 +105,6 @@ data class ÅpenBeregningRequestDto(
     @field:NotNull(message = "Bidragstype må være satt")
     @param:Schema(description = "Angir om den personen er pliktig eller mottaker", required = true)
     override val bidragstype: BidragsType,
-) : FellesBeregningRequestDto<BarnMedAlderDto>(
+) : FellesBeregningRequestDto<BarnMedFødselsdatoDto>(
     bidragsmottakerInntekt, bidragspliktigInntekt, bidragstype, barn, dittBoforhold, medforelderBoforhold, utvidetBarnetrygd, småbarnstillegg
 )

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/åpenBeregning/ÅpenBeregningsresultatDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/dto/åpenBeregning/ÅpenBeregningsresultatDto.kt
@@ -2,6 +2,7 @@ package no.nav.bidrag.bidragskalkulator.dto.åpenBeregning
 
 import io.swagger.v3.oas.annotations.media.Schema
 import java.math.BigDecimal
+import java.time.LocalDate
 
 @Schema(description = "Inneholder beregningsresultater for hvert barn i forespørselen")
 data class ÅpenBeregningsresultatDto(
@@ -10,8 +11,8 @@ data class ÅpenBeregningsresultatDto(
 
 @Schema(description = "Beregnet barnebidrag for et enkelt barn")
 data class ÅpenBeregningsresultatBarnDto(
-    @field:Schema(description = "Alder til barnet", required = true, example = "10")
-    val alder: Int,
+    @field:Schema(description = "Fødselsdato til barnet", required = true, example = "2015-06-30")
+    val fødselsdato: LocalDate,
 
     @field:Schema(description = "Beregnet barnebidrag", example = "3200")
     val sum: BigDecimal

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapper.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapper.kt
@@ -56,8 +56,8 @@ class BeregningsgrunnlagMapper(
         val bmTilleggÅrlig = beregnBmTilleggÅrlig(dto)
 
         val grunnlag = dto.barn.mapIndexed { index, barn ->
-            val barnReferanse = barnReferanse(barn.alder.toString(), index)
-            val fødselsdato = barn.getEstimertFødselsdato()
+            val barnReferanse = barnReferanse(barn.fødselsdato.toString(), index)
+            val fødselsdato = barn.fødselsdato
 
             val grunnlagListe = lagGrunnlagsliste(
                 barn = barn,

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/BeregningService.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/service/BeregningService.kt
@@ -17,12 +17,16 @@ import no.nav.bidrag.bidragskalkulator.model.FamilieRelasjon
 import no.nav.bidrag.bidragskalkulator.utils.asyncCatching
 import no.nav.bidrag.bidragskalkulator.utils.kalkulerAlder
 import no.nav.bidrag.commons.util.secureLogger
+import no.nav.bidrag.domene.enums.grunnlag.Grunnlagstype
 import no.nav.bidrag.domene.ident.Personident
 import no.nav.bidrag.domene.tid.ÅrMånedsperiode
 import no.nav.bidrag.transport.behandling.beregning.barnebidrag.ResultatPeriode
 import no.nav.bidrag.transport.behandling.beregning.felles.BeregnGrunnlag
+import no.nav.bidrag.transport.behandling.felles.grunnlag.Person
+import no.nav.bidrag.transport.behandling.felles.grunnlag.innholdTilObjekt
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
+import java.time.LocalDate
 import java.time.YearMonth
 import kotlin.time.measureTimedValue
 
@@ -94,7 +98,9 @@ class BeregningService(
         return beregnet.map { it ->
             ÅpenBeregningsresultatBarnDto(
                 sum = summerBeregnedeBeløp(it.beregnetBarnebidragResultat.beregnetBarnebidragPeriodeListe),
-                alder = alderFraBarnReferanse(it.søknadsbarnreferanse) ?: error("Ugyldig barnReferanse: ${it.søknadsbarnreferanse}")
+                fødselsdato = finnBarnFødselsdatoFraGrunnlag(
+                    it.søknadsbarnreferanse,
+                    grunnlag)
 
             )
         }
@@ -143,17 +149,9 @@ class BeregningService(
     private fun summerBeregnedeBeløp(periodeListe: List<ResultatPeriode>): BigDecimal =
         periodeListe.sumOf { it.resultat.beløp ?: BigDecimal.ZERO }
 
-    private fun alderFraBarnReferanse(referanse: String): Int? {
-        val prefix = BeregningsgrunnlagMapper.Referanser.SØKNADSBARN
-        if (!referanse.startsWith(prefix)) return null
-
-        val rest = referanse.removePrefix(prefix)
-        if (rest.isBlank()) return null
-
-        val alderDel = rest.substringBefore('_')
-
-        if (alderDel.isEmpty() || alderDel.any { !it.isDigit() }) return null
-        return alderDel.toInt()
+    private fun finnBarnFødselsdatoFraGrunnlag(referanse: String, grunnlag: List<BeregnGrunnlag>): LocalDate {
+        return grunnlag.first { it.søknadsbarnReferanse === referanse }
+            .grunnlagListe.first { it.type === Grunnlagstype.PERSON_SØKNADSBARN }
+            .innholdTilObjekt<Person>().fødselsdato
     }
-
 }

--- a/src/main/kotlin/no/nav/bidrag/bidragskalkulator/validering/BeregningRequestValidator.kt
+++ b/src/main/kotlin/no/nav/bidrag/bidragskalkulator/validering/BeregningRequestValidator.kt
@@ -4,11 +4,14 @@ import no.nav.bidrag.bidragskalkulator.dto.BidragsType.*
 import no.nav.bidrag.bidragskalkulator.dto.FellesBeregningRequestDto
 import no.nav.bidrag.bidragskalkulator.dto.IFellesBarnDto
 import no.nav.bidrag.bidragskalkulator.dto.VoksneOver18Type
-import no.nav.bidrag.bidragskalkulator.dto.åpenBeregning.BarnMedAlderDto
+import no.nav.bidrag.bidragskalkulator.dto.åpenBeregning.BarnMedFødselsdatoDto
 import no.nav.bidrag.bidragskalkulator.exception.UgyldigBeregningRequestException
+import java.math.BigDecimal
 
 object BeregningRequestValidator {
     private const val MAKS_ALDER_FOR_BARNETILSYN = 10
+    private const val MIN_MÅNED_KONTANTSTØTTE = 13
+    private const val MAX_MÅNED_KONTANTSTØTTE = 19
 
     fun <T : IFellesBarnDto, R : FellesBeregningRequestDto<T>> valider(dto: R) {
         // Utvidet barnetrygd
@@ -26,13 +29,13 @@ object BeregningRequestValidator {
         // Barnetilsyn-regler:
 
         barneliste
-            .filterIsInstance<BarnMedAlderDto>()
+            .filterIsInstance<BarnMedFødselsdatoDto>()
             .forEach { barn ->
                 val barnetilsyn = barn.barnetilsyn ?: return@forEach
 
                 // 1) Alder: barnetilsyn er ikke tillatt over 10 år
-                if (barn.alder > MAKS_ALDER_FOR_BARNETILSYN) {
-                    feil("Barnetilsyn kan ikke oppgis for barn over $MAKS_ALDER_FOR_BARNETILSYN år (barnets alder=${barn.alder}).")
+                if (barn.getAlder() > MAKS_ALDER_FOR_BARNETILSYN) {
+                    feil("Barnetilsyn kan ikke oppgis for barn over $MAKS_ALDER_FOR_BARNETILSYN år (barnets fødselsdato=${barn.fødselsdato}).")
                 }
 
                 // 2) Enten/eller: kan ikke sende både månedligUtgift og plassType
@@ -53,10 +56,13 @@ object BeregningRequestValidator {
                 feil("kontantstøtte.deles kan ikke settes uten at beløp også er satt (barn[$index])")
             }
 
-            if (beløp != null) {
-                val alder = (barn as? BarnMedAlderDto)?.alder
-                if (alder != null && alder != 1) {
-                    feil("Kontantstøtte kan kun settes for barn som er 1 år (barn[$index] har alder=$alder)")
+            if (beløp != null && beløp > BigDecimal.ZERO) {
+                val antallMånederFraFødselsdato = (barn as? BarnMedFødselsdatoDto)?.getAntallMåneder()
+                if (antallMånederFraFødselsdato != null &&
+                    (antallMånederFraFødselsdato < MIN_MÅNED_KONTANTSTØTTE ||
+                            antallMånederFraFødselsdato > MAX_MÅNED_KONTANTSTØTTE)
+                ) {
+                    feil("Kontantstøtte kan kun settes for barn som er mellom 13 og 19 måneder (barn[$index] har antall måneder=$antallMånederFraFødselsdato)")
                 }
             }
         }
@@ -64,7 +70,7 @@ object BeregningRequestValidator {
         // Småbarnstillegg
         if (dto.småbarnstillegg) {
             val harBarn0Til3År = barneliste
-                .mapNotNull { (it as? BarnMedAlderDto)?.alder }
+                .mapNotNull { (it as? BarnMedFødselsdatoDto)?.getAlder() }
                 .any { it in 0..3 }
 
             if (!harBarn0Til3År) {

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/AbstractControllerTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/AbstractControllerTest.kt
@@ -1,5 +1,6 @@
 package no.nav.bidrag.bidragskalkulator.controller
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
@@ -37,7 +38,7 @@ abstract class AbstractControllerTest {
     @Autowired
     protected lateinit var ugyldigOAuth2Token: String
 
-    protected val objectMapper = jacksonObjectMapper()
+    protected val objectMapper = ObjectMapper()
         .registerKotlinModule()
         .registerModule(JavaTimeModule())
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/BeregningControllerTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/controller/BeregningControllerTest.kt
@@ -1,5 +1,9 @@
 package no.nav.bidrag.bidragskalkulator.controller
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import kotlinx.coroutines.runBlocking
@@ -9,7 +13,7 @@ import no.nav.bidrag.bidragskalkulator.dto.BeregningsresultatBarnDto
 import no.nav.bidrag.bidragskalkulator.dto.BeregningsresultatDto
 import no.nav.bidrag.bidragskalkulator.dto.BidragsType
 import no.nav.bidrag.bidragskalkulator.dto.BoforholdDto
-import no.nav.bidrag.bidragskalkulator.dto.åpenBeregning.BarnMedAlderDto
+import no.nav.bidrag.bidragskalkulator.dto.åpenBeregning.BarnMedFødselsdatoDto
 import no.nav.bidrag.bidragskalkulator.dto.åpenBeregning.ÅpenBeregningRequestDto
 import no.nav.bidrag.bidragskalkulator.service.BeregningService
 import no.nav.bidrag.domene.enums.beregning.Samværsklasse
@@ -28,10 +32,13 @@ import no.nav.bidrag.bidragskalkulator.dto.VoksneOver18Type
 import no.nav.bidrag.bidragskalkulator.dto.åpenBeregning.ÅpenBeregningsresultatBarnDto
 import no.nav.bidrag.bidragskalkulator.dto.åpenBeregning.ÅpenBeregningsresultatDto
 import no.nav.bidrag.domene.enums.barnetilsyn.Tilsynstype
+import java.time.LocalDate
 
 class BeregningControllerTest : AbstractControllerTest() {
     @MockkBean(relaxUnitFun = true)
     private lateinit var beregningService: BeregningService
+
+    val today = LocalDate.now()
 
     @Test
     fun `skal bekrefte at mock OAuth2-server kjører`() {
@@ -42,6 +49,7 @@ class BeregningControllerTest : AbstractControllerTest() {
 
     @BeforeEach
     fun setupMocks() {
+
         every { runBlocking { beregningService.beregnBarnebidrag(mockGyldigRequest) } } returns mockRespons
         every { runBlocking { beregningService.beregnBarnebidragAnonym(any()) } } returns
                 mockÅpenRespons
@@ -79,8 +87,8 @@ class BeregningControllerTest : AbstractControllerTest() {
         val ugyldigRequest = mockGyldigÅpenRequest.copy(
             bidragstype = BidragsType.MOTTAKER,
             barn = listOf(
-                BarnMedAlderDto(
-                    alder = 2,
+                BarnMedFødselsdatoDto(
+                    fødselsdato = today.minusYears(2),
                     samværsklasse = Samværsklasse.SAMVÆRSKLASSE_0,
                 )
             ),
@@ -99,7 +107,7 @@ class BeregningControllerTest : AbstractControllerTest() {
                 antallBarnUnder18BorFast = 1,
                 voksneOver18Type = setOf(VoksneOver18Type.EGNE_BARN_OVER_18),
                 antallBarnOver18Vgs = null
-            )
+            ),
         )
 
         postRequest("/api/v1/beregning/barnebidrag/åpen", request)
@@ -122,35 +130,43 @@ class BeregningControllerTest : AbstractControllerTest() {
     }
 
     @Test
-    fun `skal returnere 400 hvis kontantstøtte er satt og alder ikke er 1`() {
+    fun `skal returnere 400 hvis kontantstøtte er satt og barn ikke er mellom 13 og 19 måneder`() {
+        val fødselsdato = today.minusMonths(24)
+
         val request = mockGyldigÅpenRequest.copy(
             bidragstype = BidragsType.MOTTAKER,
             barn = listOf(
-                BarnMedAlderDto(
-                    alder = 2,
+                BarnMedFødselsdatoDto(
+                    fødselsdato = fødselsdato,
                     samværsklasse = Samværsklasse.SAMVÆRSKLASSE_2,
                     kontantstøtte = KontantstøtteDto(beløp = BigDecimal("500"))
-                ),
+                )
             )
         )
 
         postRequest("/api/v1/beregning/barnebidrag/åpen", request)
             .andExpect(status().isBadRequest)
-            .andExpect(jsonPath("$.detail").value("Kontantstøtte kan kun settes for barn som er 1 år (barn[0] har alder=2)"))
+            .andExpect(
+                jsonPath("$.detail").value(
+                    "Kontantstøtte kan kun settes for barn som er mellom 13 og 19 måneder (barn[0] har antall måneder=24)"
+                )
+            )
 
         verify(exactly = 0) { runBlocking { beregningService.beregnBarnebidragAnonym(any()) } }
     }
 
     @Test
-    fun `skal returnere 200 OK når kontantstøtte er satt for barn som er 1 år`() {
+    fun `skal returnere 200 OK når kontantstøtte er satt for barn mellom 13 og 19 måneder`() {
+        val fødselsdato = today.minusMonths(14)
+
         val request = mockGyldigÅpenRequest.copy(
             bidragstype = BidragsType.MOTTAKER,
             barn = listOf(
-                BarnMedAlderDto(
-                    alder = 1,
+                BarnMedFødselsdatoDto(
+                    fødselsdato = fødselsdato,
                     samværsklasse = Samværsklasse.SAMVÆRSKLASSE_2,
                     kontantstøtte = KontantstøtteDto(beløp = BigDecimal("500"))
-                ),
+                )
             )
         )
 
@@ -165,8 +181,8 @@ class BeregningControllerTest : AbstractControllerTest() {
         val request = mockGyldigÅpenRequest.copy(
             bidragstype = BidragsType.MOTTAKER,
             barn = listOf(
-                BarnMedAlderDto(
-                    alder = 1,
+                BarnMedFødselsdatoDto(
+                    fødselsdato = today.minusYears(1),
                     samværsklasse = Samværsklasse.SAMVÆRSKLASSE_2,
                     kontantstøtte = KontantstøtteDto(beløp = null, deles = true)
                 )
@@ -204,7 +220,7 @@ class BeregningControllerTest : AbstractControllerTest() {
         val request = mockGyldigÅpenRequest.copy(
             bidragstype = BidragsType.MOTTAKER,
             småbarnstillegg = true,
-            barn = mockGyldigÅpenRequest.barn.map { it.copy(alder = 4, kontantstøtte = null) },
+            barn = mockGyldigÅpenRequest.barn.map { it.copy(fødselsdato = today.minusYears(4), kontantstøtte = null) },
         )
 
         postRequest("/api/v1/beregning/barnebidrag/åpen", request)
@@ -221,7 +237,7 @@ class BeregningControllerTest : AbstractControllerTest() {
         val request = mockGyldigÅpenRequest.copy(
             bidragstype = BidragsType.MOTTAKER,
             barn = mockGyldigÅpenRequest.barn
-                .map { it.copy(alder = 1, barnetilsyn = BarnetilsynDto(månedligUtgift = BigDecimal("1200"))) },
+                .map { it.copy(fødselsdato = today.minusYears(1), barnetilsyn = BarnetilsynDto(månedligUtgift = BigDecimal("1200"))) },
         )
 
         postRequest("/api/v1/beregning/barnebidrag/åpen", request)
@@ -256,24 +272,25 @@ class BeregningControllerTest : AbstractControllerTest() {
 
     @Test
     fun `skal gi 400 når barn er over 10 år og barnetilsyn månedligUtgift er gitt`() {
+        val fødselsdato = today.minusYears(11)
+
         val request = mockGyldigÅpenRequest.copy(
             bidragstype = BidragsType.MOTTAKER,
             barn = mockGyldigÅpenRequest.barn.mapIndexed { idx, barn ->
                 if (idx == 0) {
                     barn.copy(
-                        alder = 11,
-                        barnetilsyn = barn.barnetilsyn?.copy(
-                            månedligUtgift = BigDecimal("1200")
-                        )
+                        fødselsdato = fødselsdato,
+                        barnetilsyn = barn.barnetilsyn?.copy(månedligUtgift = BigDecimal("1200"))
                     )
-                } else barn }
+                } else barn
+            }
         )
 
         postRequest("/api/v1/beregning/barnebidrag/åpen", request)
             .andExpect(status().isBadRequest)
             .andExpect(
                 jsonPath("$.detail").value(
-                    "Barnetilsyn kan ikke oppgis for barn over 10 år (barnets alder=11)."
+                    "Barnetilsyn kan ikke oppgis for barn over 10 år (barnets fødselsdato=$fødselsdato)."
                 )
             )
     }
@@ -303,6 +320,7 @@ class BeregningControllerTest : AbstractControllerTest() {
 
     companion object TestData {
         private val personIdent = genererPersonident()
+        val today = LocalDate.now()
 
         val mockGyldigRequest = BeregningRequestDto(
             bidragsmottakerInntekt = ForelderInntektDto(inntekt = BigDecimal("500000")),
@@ -322,8 +340,8 @@ class BeregningControllerTest : AbstractControllerTest() {
             bidragspliktigInntekt = ForelderInntektDto(inntekt = BigDecimal("400000")),
             bidragstype = BidragsType.PLIKTIG,
             barn = listOf(
-                BarnMedAlderDto(
-                    alder = 1,
+                BarnMedFødselsdatoDto(
+                    fødselsdato = today.minusYears(1),
                     samværsklasse = Samværsklasse.SAMVÆRSKLASSE_0,
                     barnetilsyn = BarnetilsynDto(månedligUtgift = BigDecimal("1200")),
                     inntekt = BigDecimal.ZERO,
@@ -345,12 +363,11 @@ class BeregningControllerTest : AbstractControllerTest() {
                 )
             )
         )
-
         val mockÅpenRespons = ÅpenBeregningsresultatDto(
             resultater = listOf(
                 ÅpenBeregningsresultatBarnDto(
                     sum = BigDecimal(100),
-                    alder = 10,
+                    fødselsdato = today,
                 )
             )
         )

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagBuilderTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagBuilderTest.kt
@@ -409,7 +409,7 @@ class BeregningsgrunnlagBuilderTest {
 
         @Test
         fun `skal bygge samværsgrunnlag med korrekt klasse`() {
-            val barn = lagBarnDto(alder = 1, samværklasse = Samværsklasse.SAMVÆRSKLASSE_3)
+            val barn = lagBarnDto(fødselsdato = LocalDate.now().minusYears(1), samværklasse = Samværsklasse.SAMVÆRSKLASSE_3)
             val beregningRequest = lagBeregningRequestDto(
                 bmInntekt = ForelderInntektDto(BigDecimal("300000")),
                 bpInntekt = ForelderInntektDto(BigDecimal("700000")),
@@ -431,11 +431,11 @@ class BeregningsgrunnlagBuilderTest {
 
         @Test
         fun `skal bygge mottatt faktisk utgift med riktig grunnlagstype`() {
-            val barn = lagBarnDto(alder = 1, samværklasse = Samværsklasse.SAMVÆRSKLASSE_3, barnetilsyn = BarnetilsynDto(
+            val barn = lagBarnDto(fødselsdato = LocalDate.now().minusYears(1), samværklasse = Samværsklasse.SAMVÆRSKLASSE_3, barnetilsyn = BarnetilsynDto(
                 BigDecimal("1200")))
 
             val resultat = builder.byggMottattFaktiskUtgift(
-                barn.getEstimertFødselsdato(), "Person_Søknadsbarn_0", barn.barnetilsyn?.månedligUtgift ?: BigDecimal.ZERO
+                barn.fødselsdato, "Person_Søknadsbarn_0", barn.barnetilsyn?.månedligUtgift ?: BigDecimal.ZERO
             )
 
             assertThat(resultat.type).isEqualTo(Grunnlagstype.FAKTISK_UTGIFT_PERIODE)

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapperTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/mapper/BeregningsgrunnlagMapperTest.kt
@@ -83,8 +83,8 @@ class BeregningsgrunnlagMapperTest {
 
     @Test
     fun `skal mappe ÅpenBeregningRequestDto med to barn til BeregnGrunnlag`() {
-        val barn1 = lagBarnDto(alder = 1)
-        val barn2 = lagBarnDto(alder = 2)
+        val barn1 = lagBarnDto(fødselsdato = LocalDate.now().minusYears(1))
+        val barn2 = lagBarnDto(fødselsdato = LocalDate.now().minusYears(2))
         val beregningRequest = lagBeregningRequestDto(
             bmInntekt = ForelderInntektDto(BigDecimal("300000")),
             bpInntekt = ForelderInntektDto(BigDecimal("700000")),
@@ -102,8 +102,8 @@ class BeregningsgrunnlagMapperTest {
 
     @Test
     fun `skal ha riktig antall grunnlagselementer`() {
-        val barn1 = lagBarnDto(alder = 1)
-        val barn2 = lagBarnDto(alder = 2)
+        val barn1 = lagBarnDto(fødselsdato = LocalDate.now().minusYears(1))
+        val barn2 = lagBarnDto(fødselsdato = LocalDate.now().minusYears(2))
         val beregningRequest = lagBeregningRequestDto(
             bmInntekt = ForelderInntektDto(BigDecimal("300000")),
             bpInntekt = ForelderInntektDto(BigDecimal("700000")),
@@ -121,7 +121,7 @@ class BeregningsgrunnlagMapperTest {
     inner class StønadstypeGrunnlag {
         @Test
         fun `skal sette stønadstype til BIDRAG18AAR for barn over 18`() {
-            val barn = lagBarnDto(alder = 18)
+            val barn = lagBarnDto(fødselsdato = LocalDate.now().minusYears(18))
             val beregningRequest = lagBeregningRequestDto(
                 bmInntekt = ForelderInntektDto(BigDecimal("300000")),
                 bpInntekt = ForelderInntektDto(BigDecimal("700000")),
@@ -141,7 +141,7 @@ class BeregningsgrunnlagMapperTest {
 
         @Test
         fun `skal sette stønadstype til BIDRAG for barn under 18`() {
-            val barn = lagBarnDto(alder = 17)
+            val barn = lagBarnDto(fødselsdato = LocalDate.now().minusYears(17))
             val beregningRequest = lagBeregningRequestDto(
                 bmInntekt = ForelderInntektDto(BigDecimal("300000")),
                 bpInntekt = ForelderInntektDto(BigDecimal("700000")),
@@ -160,7 +160,7 @@ class BeregningsgrunnlagMapperTest {
         @Test
         fun `skal inkludere faktisk utgift grunnlag når barnetilsynsutgift er satt`() {
             val barn = lagBarnDto(
-                alder = 1,
+                fødselsdato = LocalDate.now().minusYears(1),
                 samværklasse = Samværsklasse.SAMVÆRSKLASSE_2,
                 barnetilsyn = BarnetilsynDto(BigDecimal("1200"))
             )
@@ -396,7 +396,7 @@ class BeregningsgrunnlagMapperTest {
 
             val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(request)
 
-            val barnRef = "${BeregningsgrunnlagMapper.Referanser.SØKNADSBARN}${request.barn.first().alder}_0"
+            val barnRef = "${BeregningsgrunnlagMapper.Referanser.SØKNADSBARN}${request.barn.first().fødselsdato}_0"
             val barnInntekt = result.first().grunnlagListe
                 .find { it.referanse == "${BeregningsgrunnlagKonstant.INNTEKT_PREFIX}$barnRef" }
 
@@ -416,7 +416,7 @@ class BeregningsgrunnlagMapperTest {
 
             val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(request)
 
-            val barnRef = "${BeregningsgrunnlagMapper.Referanser.SØKNADSBARN}${request.barn.first().alder}"
+            val barnRef = "${BeregningsgrunnlagMapper.Referanser.SØKNADSBARN}${request.barn.first().fødselsdato}"
             val barnInntekt = result.first().grunnlagListe
                 .find { it.referanse == "${BeregningsgrunnlagKonstant.INNTEKT_PREFIX}$barnRef" }
 
@@ -546,7 +546,7 @@ class BeregningsgrunnlagMapperTest {
             val result = beregningsgrunnlagMapper.mapTilBeregningsgrunnlagAnonym(request)
             val grunnlag = result.first().grunnlagListe
 
-            val barnRef = "${BeregningsgrunnlagMapper.Referanser.SØKNADSBARN}${request.barn.first().alder}_0"
+            val barnRef = "${BeregningsgrunnlagMapper.Referanser.SØKNADSBARN}${request.barn.first().fødselsdato}_0"
 
             // Mapperen skal alltid legge inn disse to bostatusene:
             assertThat(grunnlag).anyMatch { it.referanse == BeregningsgrunnlagKonstant.BOSTATUS_BIDRAGSPLIKTIG }
@@ -603,7 +603,7 @@ class BeregningsgrunnlagMapperTest {
         beregningRequest: ÅpenBeregningRequestDto,
         index: Int
     ) {
-        val forventetAlder = beregningRequest.barn[index].alder
+        val forventetAlder = beregningRequest.barn[index].fødselsdato
         assertEquals("${BeregningsgrunnlagMapper.Referanser.SØKNADSBARN}${forventetAlder}_${index}", grunnlag.søknadsbarnReferanse)
     }
 }

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/service/BeregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/service/BeregningServiceTest.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.test.runTest
 import no.nav.bidrag.beregn.barnebidrag.BeregnBarnebidragApi
 import no.nav.bidrag.bidragskalkulator.dto.BidragsType
 import no.nav.bidrag.bidragskalkulator.dto.ForelderInntektDto
-import no.nav.bidrag.bidragskalkulator.dto.åpenBeregning.BarnMedAlderDto
+import no.nav.bidrag.bidragskalkulator.dto.åpenBeregning.BarnMedFødselsdatoDto
 import no.nav.bidrag.bidragskalkulator.dto.åpenBeregning.ÅpenBeregningRequestDto
 import no.nav.bidrag.bidragskalkulator.dto.åpenBeregning.ÅpenBeregningsresultatDto
 import no.nav.bidrag.bidragskalkulator.mapper.BeregningsgrunnlagBuilder
@@ -22,12 +22,14 @@ import no.nav.bidrag.transport.behandling.beregning.barnebidrag.BeregnetBarnebid
 import no.nav.bidrag.transport.behandling.beregning.barnebidrag.BeregnetBarnebidragResultatV2
 import no.nav.bidrag.transport.behandling.beregning.barnebidrag.ResultatBeregning
 import no.nav.bidrag.transport.behandling.beregning.barnebidrag.ResultatPeriode
+import no.nav.bidrag.transport.behandling.beregning.felles.BeregnGrunnlag
 import no.nav.bidrag.transport.person.MotpartBarnRelasjonDto
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
+import java.time.LocalDate
 import java.time.YearMonth
 
 class BeregningServiceTest {
@@ -66,7 +68,7 @@ class BeregningServiceTest {
         @BeforeEach
         fun oppsett() = runTest {
             beregningRequest = mockOppsett(
-                listOf(BarnMedAlderDto(alder = 1, samværsklasse = Samværsklasse.SAMVÆRSKLASSE_2))
+                listOf(BarnMedFødselsdatoDto(fødselsdato = LocalDate.now().minusYears(1), samværsklasse = Samværsklasse.SAMVÆRSKLASSE_2))
             )
             beregningResultat = beregningService.beregnBarnebidragAnonym(beregningRequest)
         }
@@ -93,39 +95,42 @@ class BeregningServiceTest {
         }
 
         @Test
-        fun `skal returnere alder fra søknadsbarnreferanse`() {
-            assertEquals(1, beregningResultat.resultater.first().alder)
+        fun `skal mappe fødselsdato riktig fra grunnlag`() {
+            val forventetFødselsdato = beregningRequest.barn.first().fødselsdato
+            assertEquals(forventetFødselsdato, beregningResultat.resultater.first().fødselsdato)
         }
     }
 
     @Nested
-    inner class BeregningBarnebidragForToBarn {
+    inner class BeregningBarnebidragForTreBarn {
 
         private lateinit var beregningRequest: ÅpenBeregningRequestDto
         private lateinit var beregningResultat: ÅpenBeregningsresultatDto
+        private val fødselsdato4År = LocalDate.now().minusYears(4)
+        private val fødselsdato7År = LocalDate.now().minusYears(7)
 
         @BeforeEach
         fun oppsett() = runTest {
             beregningRequest = mockOppsett(
                 listOf(
-                    BarnMedAlderDto(alder = 4, samværsklasse = Samværsklasse.SAMVÆRSKLASSE_2),
-                    BarnMedAlderDto(alder = 4, samværsklasse = Samværsklasse.SAMVÆRSKLASSE_2),
-                    BarnMedAlderDto(alder = 7, samværsklasse = Samværsklasse.SAMVÆRSKLASSE_3)
+                    BarnMedFødselsdatoDto(fødselsdato = fødselsdato4År, samværsklasse = Samværsklasse.SAMVÆRSKLASSE_2),
+                    BarnMedFødselsdatoDto(fødselsdato = fødselsdato4År, samværsklasse = Samværsklasse.SAMVÆRSKLASSE_2),
+                    BarnMedFødselsdatoDto(fødselsdato = fødselsdato7År, samværsklasse = Samværsklasse.SAMVÆRSKLASSE_3)
                 )
             )
             beregningResultat = beregningService.beregnBarnebidragAnonym(beregningRequest)
         }
 
         @Test
-        fun `skal returnere to beregningsresultater for to barn`() = runTest {
+        fun `skal returnere tre beregningsresultater for tre barn`() = runTest {
             val resultat = beregningService.beregnBarnebidragAnonym(beregningRequest)
             assertEquals(3, resultat.resultater.size)
         }
 
         @Test
-        fun `skal mappe alder riktig for alle barn og kunne håndtere barn med samme alder`() {
-            val aldre = beregningResultat.resultater.map { it.alder }.sorted()
-            assertEquals(listOf(4, 4, 7), aldre)
+        fun `skal mappe fødselsdato riktig for alle barn og kunne håndtere barn med samme fødselsdato`() {
+            val fødselsdatoer = beregningResultat.resultater.map { it.fødselsdato }.sorted()
+            assertEquals(listOf(fødselsdato7År, fødselsdato4År, fødselsdato4År), fødselsdatoer)
         }
     }
 
@@ -191,7 +196,7 @@ class BeregningServiceTest {
         )
     }
 
-    private fun mockOppsett(barn: List<BarnMedAlderDto>): ÅpenBeregningRequestDto {
+    private fun mockOppsett(barn: List<BarnMedFødselsdatoDto>): ÅpenBeregningRequestDto {
         val beregningRequest = ÅpenBeregningRequestDto(
             bidragsmottakerInntekt = ForelderInntektDto(inntekt = BigDecimal("500000")),
             bidragspliktigInntekt = ForelderInntektDto(inntekt = BigDecimal("800000")),
@@ -207,14 +212,15 @@ class BeregningServiceTest {
             beregnetBarnebidragPeriodeListe = listOf(lagResultatPeriode())
         )
 
-        val resultater: List<BeregnetBarnebidragResultatV2> = barn.map { b ->
-            BeregnetBarnebidragResultatV2(
-                søknadsbarnreferanse = "${BeregningsgrunnlagMapper.Referanser.SØKNADSBARN}${b.alder}",
-                beregnetBarnebidragResultat = beregnetResultat
-            )
+        coEvery { beregnBarnebidragApi.beregnV2(any(), any()) } answers {
+            val grunnlag = secondArg<List<BeregnGrunnlag>>()
+            grunnlag.map { g ->
+                BeregnetBarnebidragResultatV2(
+                    søknadsbarnreferanse = g.søknadsbarnReferanse,
+                    beregnetBarnebidragResultat = beregnetResultat
+                )
+            }
         }
-
-        coEvery { beregnBarnebidragApi.beregnV2(any(), any()) } returns resultater
 
         return beregningRequest
     }

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/service/BeregningServiceValidationTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/service/BeregningServiceValidationTest.kt
@@ -12,11 +12,14 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import no.nav.bidrag.bidragskalkulator.dto.ForelderInntektDto
-import no.nav.bidrag.bidragskalkulator.dto.åpenBeregning.BarnMedAlderDto
+import no.nav.bidrag.bidragskalkulator.dto.åpenBeregning.BarnMedFødselsdatoDto
 import no.nav.bidrag.bidragskalkulator.dto.åpenBeregning.ÅpenBeregningRequestDto
 import no.nav.bidrag.generer.testdata.person.genererPersonident
 import java.math.BigDecimal
+import java.time.LocalDate
 
 class BeregningServiceValidationTest {
 
@@ -28,7 +31,10 @@ class BeregningServiceValidationTest {
     fun setup() {
         val factory = Validation.buildDefaultValidatorFactory()
         validator = factory.validator
-        objectMapper = ObjectMapper().registerKotlinModule()
+        objectMapper = ObjectMapper()
+            .registerKotlinModule()
+            .registerModule(JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
     }
 
     @Test
@@ -38,8 +44,8 @@ class BeregningServiceValidationTest {
             bidragspliktigInntekt = ForelderInntektDto(inntekt = BigDecimal("600000")),
             bidragstype = BidragsType.PLIKTIG,
             barn = listOf(
-                BarnMedAlderDto(
-                    alder = 1,
+                BarnMedFødselsdatoDto(
+                    fødselsdato = LocalDate.now().minusYears(1),
                     samværsklasse = Samværsklasse.SAMVÆRSKLASSE_1,
                 )
             )
@@ -59,7 +65,7 @@ class BeregningServiceValidationTest {
                 },
                 "barn": [
                     {
-                        "alder": 1,
+                        "fødselsdato": "${LocalDate.now().minusYears(1)}",
                         "samværsklasse": "SAMVÆRSKLASSE_1"
                     }
                 ]
@@ -173,7 +179,7 @@ class BeregningServiceValidationTest {
           "bidragstype": "MOTTAKER",
           "barn": [
             {
-              "alder": 1,
+              "fødselsdato": "2025-07-01",
               "samværsklasse": "SAMVÆRSKLASSE_1"
             }
           ]

--- a/src/test/kotlin/no/nav/bidrag/bidragskalkulator/utils/Testdata.kt
+++ b/src/test/kotlin/no/nav/bidrag/bidragskalkulator/utils/Testdata.kt
@@ -7,19 +7,20 @@ import no.nav.bidrag.bidragskalkulator.dto.ForelderInntektDto
 import no.nav.bidrag.bidragskalkulator.dto.KontantstøtteDto
 import no.nav.bidrag.bidragskalkulator.dto.UtvidetBarnetrygdDto
 import no.nav.bidrag.bidragskalkulator.dto.VoksneOver18Type
-import no.nav.bidrag.bidragskalkulator.dto.åpenBeregning.BarnMedAlderDto
+import no.nav.bidrag.bidragskalkulator.dto.åpenBeregning.BarnMedFødselsdatoDto
 import no.nav.bidrag.bidragskalkulator.dto.åpenBeregning.ÅpenBeregningRequestDto
 import no.nav.bidrag.domene.enums.beregning.Samværsklasse
 import java.math.BigDecimal
+import java.time.LocalDate
 
 fun lagBarnDto(
-    alder: Int = 1,
+    fødselsdato: LocalDate = LocalDate.now().minusYears(1),
     samværklasse: Samværsklasse = Samværsklasse.SAMVÆRSKLASSE_2,
     barnetilsyn: BarnetilsynDto? = null,
     kontantstøtte: KontantstøtteDto? = null,
     inntekt: BigDecimal? = null
-) = BarnMedAlderDto(
-    alder = alder,
+) = BarnMedFødselsdatoDto(
+    fødselsdato = fødselsdato,
     samværsklasse = samværklasse,
     barnetilsyn = barnetilsyn,
     kontantstøtte = kontantstøtte,
@@ -39,7 +40,7 @@ fun lagBeregningRequestDto(
     bmInntekt: ForelderInntektDto,
     bpInntekt: ForelderInntektDto,
     bidragstype: BidragsType,
-    barn: List<BarnMedAlderDto> = emptyList(),
+    barn: List<BarnMedFødselsdatoDto> = emptyList(),
     dittBoforhold: BoforholdDto? = null,
     medforelderBoforhold: BoforholdDto? = null,
     utvidetBarnetrygd: UtvidetBarnetrygdDto? = null,


### PR DESCRIPTION
## Description

- Updated the data model for children in tests to utilize birthdate instead of age.
- Modified the data model for children in calculations to replace age with birthdate.
- Added schema for `VoksneOver18Type` in Swagger configuration.
